### PR TITLE
Fix district needs view dropping needs without loaded person

### DIFF
--- a/client/src/pages/Needs.tsx
+++ b/client/src/pages/Needs.tsx
@@ -32,7 +32,6 @@ export default function Needs() {
       person,
       campus,
     };
-  }).filter(item => item.person); // Only show needs for people we can see
 
   const toggleNeedActive = trpc.needs.toggleActive.useMutation({
     onSuccess: () => {
@@ -100,6 +99,10 @@ export default function Needs() {
       ) : (
         <div className="grid gap-4">
           {enrichedNeeds.map((item) => (
+                          // Warn if person data is missing (helps diagnose sync issues)
+                          if (!item.person) {
+                                              console.warn(`Need ${item.need.id} has missing person data for personId: ${item.need.personId}`);
+                          }
             <Card key={item.id} className="hover:shadow-md transition-shadow">
               <CardContent className="p-6">
                 <div className="flex items-start justify-between gap-4">
@@ -108,8 +111,7 @@ export default function Needs() {
                     <div className="flex items-center gap-3">
                       <div className="flex items-center gap-2">
                         <User className="h-4 w-4 text-gray-500" />
-                        <span className="font-semibold text-lg">{item.person?.name}</span>
-                      </div>
+                            <span className="font-semibold text-lg">{item.person?.name || `Unknown person (ID: ${item.need.personId})`}</span>                      </div>
                       {item.campus && (
                         <div className="flex items-center gap-1 text-sm text-gray-600">
                           <MapPin className="h-3 w-3" />


### PR DESCRIPTION
Root cause: Frontend was filtering out needs where person lookup failed via .filter(item => item.person), causing district-visible needs to disappear from the /needs view when person data wasn't loaded.

Changes:
- Removed .filter(item => item.person) that dropped needs with unresolved person references
- Added console.warn to detect and log missing person data (needId + personId) for debugging
- Added placeholder display: shows "Unknown person (ID: {personId})" when person is null instead of hiding the need

This ensures needs remain visible as "action drivers" per product requirements, even when 

## Verification Steps (Staging)
1. Create a new need and set it to `DISTRICT_VISIBLE`
2. Ensure the need's `personId` references a person that is NOT currently loaded in `allPeople` (to simulate the orphan case)
3. Navigate to `/needs` district view
4. Confirm the need appears in the list with placeholder text: "Unknown person (ID: {personId})"
5. Check browser console for warning: `Need {needId} has missing person data for personId: {personId}`
6. Verify the need remains actionable and visible (not dropped from the view)

This fix ensures district-visible needs are never silently hidden due to person enrichment failures.person enrichment fails.