### PR TITLE
feat: wire devBypassAuth for local dev auth bypass

### DIFF
--- a/server/_core/trpc.ts
+++ b/server/_core/trpc.ts
@@ -2,6 +2,7 @@ import { NOT_ADMIN_ERR_MSG, UNAUTHED_ERR_MSG } from '@shared/const';
 import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
 import type { TrpcContext } from "./context";
+import { ENV } from "./env";
 
 const t = initTRPC.context<TrpcContext>().create({
   transformer: superjson,
@@ -13,7 +14,9 @@ export const publicProcedure = t.procedure;
 const requireUser = t.middleware(async opts => {
   const { ctx, next } = opts;
 
-  if (!ctx.user) {
+  // Dev-only bypass: ENV.devBypassAuth is only true when NODE_ENV === 'development'
+  // This guardrail is enforced in env.ts and cannot be overridden in production
+  if (!ctx.user && !ENV.devBypassAuth) {
     throw new TRPCError({ code: "UNAUTHORIZED", message: UNAUTHED_ERR_MSG });
   }
 


### PR DESCRIPTION
Enable ENV.devBypassAuth to actually bypass auth in dev environments. Production safety is ensured via env.ts which only allows devBypassAuth to be true when NODE_ENV === 'development'.

Changes:
- Import ENV in trpc.ts
- Update requireUser middleware to skip auth check if devBypassAuth is true
- Add inline comment explaining the production safety guardrail