### PR TITLE
Add @sentry/react dependency version 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+        "@sentry/react": "^8.0.0",
     "@tanstack/react-query": "^5.90.2",
     "@tiptap/extension-color": "^3.13.0",
     "@tiptap/extension-font-family": "^3.13.0",


### PR DESCRIPTION
Fixes Railway staging build blocker by adding missing @sentry/react dependency.

This unblocks the Sentry integration implementation as identified in SENTRY-DEP-001.