### PR TITLE
Revert "Add @sentry/react dependency version 8.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
-        "@sentry/react": "^8.0.0",
     "@tanstack/react-query": "^5.90.2",
     "@tiptap/extension-color": "^3.13.0",
     "@tiptap/extension-font-family": "^3.13.0",


### PR DESCRIPTION
Reverts sirjamesoffordii/CMC-Go#45

## Reason
PR #45 added @sentry/react@8.0.0 to package.json but did not regenerate the pnpm-lock.yaml file. This causes the build to fail with: `ERR_PNPM_OUTDATED_LOCKFILE - Cannot install with "frozen-lockfile"`.

## What needs to be done for proper Sentry integration:

1. **Install**: Run `pnpm add @sentry/react` locally to generate the correct lockfile entries
2. 2. **Configure**: Initialize Sentry in main.tsx with:
3.    ```javascript
4.    import * as Sentry from "@sentry/react"
5.    Sentry.init({
6.      dsn: "...",
7.      sendDefaultPii: true
8.    });
9.    ```
10. 3. **Verify**: Add a test error button component to verify Sentry is capturing errors
Sentry setup guide: https://sir-james-offord-ii.sentry.io/issues/?guidedStep=1

This reverts the broken PR. A new PR should be created with the complete, proper Sentry integration that includes the updated lockfile.