### PR TITLE
fix(ci): resolve workflow yaml parse error (issue #51)

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -2,56 +2,56 @@ name: Test and Code Coverage
 
 on:
   push:
-      branches: [ main, develop ]
-        pull_request:
-            branches: [ main, develop ]
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
 
-            jobs:
-              test-and-coverage:
-                  runs-on: ubuntu-latest
+jobs:
+  test-and-coverage:
+    runs-on: ubuntu-latest
 
-                      services:
-                            postgres:
-                                    image: postgres:15
-                                            env:
-                                                      POSTGRES_USER: root
-                                                                POSTGRES_PASSWORD: password
-                                                                          POSTGRES_DB: cmc_test
-                                                                                  options: >-
-                                                                                            --health-cmd pg_isready
-                                                                                                      --health-interval 10s
-                                                                                                                --health-timeout 5s
-                                                                                                                          --health-retries 5
-                                                                                                                                  ports:
-                                                                                                                                            - 5432:5432
-                                                                                                                                            
-                                                                                                                                                steps:
-                                                                                                                                                      - uses: actions/checkout@v4
-                                                                                                                                                      
-                                                                                                                                                            - name: Setup pnpm
-                                                                                                                                                                    uses: pnpm/action-setup@v2
-                                                                                                                                                                            with:
-                                                                                                                                                                                      version: 8
-                                                                                                                                                                                      
-                                                                                                                                                                                            - name: Setup Node.js
-                                                                                                                                                                                                    uses: actions/setup-node@v4
-                                                                                                                                                                                                            with:
-                                                                                                                                                                                                                      node-version: '18'
-                                                                                                                                                                                                                                cache: 'pnpm'
-                                                                                                                                                                                                                                
-                                                                                                                                                                                                                                      - name: Install dependencies
-                                                                                                                                                                                                                                              run: pnpm install --frozen-lockfile
-                                                                                                                                                                                                                                              
-                                                                                                                                                                                                                                                    - name: Run tests with coverage
-                                                                                                                                                                                                                                                            run: pnpm jest --coverage
-                                                                                                                                                                                                                                                                    env:
-                                                                                                                                                                                                                                                                              DATABASE_URL: postgres://root:password@localhost:5432/cmc_test
-                                                                                                                                                                                                                                                                              
-                                                                                                                                                                                                                                                                                    - name: Upload coverage reports to Codecov
-                                                                                                                                                                                                                                                                                            uses: codecov/codecov-action@v5
-                                                                                                                                                                                                                                                                                                    with:
-                                                                                                                                                                                                                                                                                                              token: ${{ secrets.CODECOV_TOKEN }}
-                                                                                                                                                                                                                                                                                                                        files: ./coverage/coverage-final.json
-                                                                                                                                                                                                                                                                                                                                  flags: unittests
-                                                                                                                                                                                                                                                                                                                                            name: codecov-umbrella
-                                                                                                                                                                                                                                                                                                                                                      fail_ci_if_error: false
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: root
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: cmc_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests with coverage
+        run: pnpm jest --coverage
+        env:
+          DATABASE_URL: postgres://root:password@localhost:5432/cmc_test
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/coverage-final.json
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false


### PR DESCRIPTION
## Summary
Fixes #51 - resolves critical YAML workflow syntax error that was blocking CI/CD operations.

## Root Cause
GitHub web editor was stripping newline characters during file edits, causing the YAML parser to fail on line 4.

## Solution
- Recreated workflow file from scratch using github.dev (VS Code web editor)
- Ensured proper UTF-8 (no BOM) encoding and LF line endings
- Verified proper 2-space YAML indentation throughout

## Verification
- File now displays correctly in raw view
- YAML structure is valid
- Ready for merge to unblock CI/CD pipeline