### PR TITLE
User - Sir James: Prefer Edge Tools previews

### DIFF
--- a/.github/agents/user-sir-james.agent.md
+++ b/.github/agents/user-sir-james.agent.md
@@ -38,5 +38,10 @@ Token usage (GitHub automation):
 - If GitHub automation requires a token, use an operator-provided token ephemerally via `$env:GITHUB_TOKEN` (secure prompt, do not print/log, clear after use). Never commit tokens.
 
 Continuous mode:
-- Keep going through the next best step until Sir James’ request is Done/Blocked.
+- Keep going through the next best step until Sir James' request is Done/Blocked.
 - If blocked: write one concise escalation note for the Coordinator (Issue/PR comment) with A/B/C options and your recommended default.
+
+Preview policy (VS Code):
+- Prefer **Microsoft Edge Tools** embedded browser for UI previews.
+- Avoid **Simple Browser** unless Sir James explicitly asks for it.
+- Recommended flow: Activity Bar → Microsoft Edge Tools → Launch Instance → paste `http://127.0.0.1:3000`.

--- a/.github/prompts/user-sir-james.prompt.md
+++ b/.github/prompts/user-sir-james.prompt.md
@@ -21,6 +21,10 @@ Hard constraints:
 - Keep diffs minimal; avoid unrelated refactors.
 - Always produce an audit artifact (PR preferred) and report every meaningful action via Issue/PR comment using the standard update format.
 
+Local preview default (VS Code):
+- Use **Microsoft Edge Tools** embedded browser (not Simple Browser) for UI previews.
+- Preferred flow: Microsoft Edge Tools → Launch Instance → paste `http://127.0.0.1:3000`.
+
 PR/merge defaults:
 - Default: open PR into `staging` and request Coordinator review.
 - Only if Sir James explicitly asks: approve + merge your own PR after evidence gates pass, and leave a final audit comment tagging the Coordinator.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,11 +3,20 @@
         "main"
     ],
     "sentry.enabled": true,
-    "sentry.authToken": "sntryu_4236be06f8147090b74fbd9899804addce64faff0b1aa71c44ae401",
     "sentry.organization": "sir-james-offord-ii",
     "sentry.projects": ["cmc-go-client"],
     "sentry.serverUrl": "https://sentry.io",
     "sentryAutoFix.sentryUrl": "https://sentry.io",
-    "sentryAutoFix.apiToken": "sntryu_Bc3082385e03c90e38D85d64fde5eaf80bee570758fb34e2f1b55c",
-    "sentryAutoFix.projectSlugs": ["sir-james-offord-ii/cmc-go-client"]
+    "sentryAutoFix.projectSlugs": ["sir-james-offord-ii/cmc-go-client"],
+
+    // Embedded preview: prefer Microsoft Edge Tools (not Simple Browser).
+    "vscode-edge-devtools.defaultUrl": "http://127.0.0.1:3000",
+    "vscode-edge-devtools.webRoot": "${workspaceFolder}/client",
+
+    // If Ports auto-forwarding is ever used, open externally (avoids Simple Browser).
+    "remote.portsAttributes": {
+        "3000": {
+            "onAutoForward": "openBrowser"
+        }
+    }
 }


### PR DESCRIPTION
**STATUS:** Ready for Review\n\n**WHAT CHANGED:**\n- Set workspace defaults for Microsoft Edge Tools embedded browser (default URL: http://127.0.0.1:3000).\n- Add guidance for User - Sir James agent/prompts to prefer Edge Tools (Launch Instance) over Simple Browser for previews.\n- Remove Sentry token fields from .vscode/settings.json (tokens should not be committed).\n\n**EVIDENCE:**\n- Embedded preview works via Activity Bar  Microsoft Edge Tools  Launch Instance.\n\n**NEXT:**\n- Merge requested by Sir James.