### PR TITLE
docs: remove merge-conflict markers in agent role files

### DIFF
--- a/.github/agents/browser-operator.agent.md
+++ b/.github/agents/browser-operator.agent.md
@@ -16,7 +16,7 @@ When a task affects “build readiness”, report evidence so the Coordinator ca
 - Do not invent settings.
 - Do not store secrets in repo or issue comments.
 - In Rapid Dev Mode, proceed without lecturing; still avoid committing secrets.
-<<<<<<< HEAD
+
 
 ### Evidence standard
 

--- a/.github/agents/builder.agent.md
+++ b/.github/agents/builder.agent.md
@@ -12,7 +12,6 @@ You implement work assigned by the **Coordinator** and stay aligned to the curre
 - Commit with prefix: `agent(builder): ...`
 - Open a PR and link it to the Issue.
 
-<<<<<<< HEAD
 ### Coordination rule
 
 - If the Issue is ambiguous, stop and ask the Coordinator in the Issue comments before coding.
@@ -20,7 +19,6 @@ You implement work assigned by the **Coordinator** and stay aligned to the curre
 - Run the cheapest relevant checks (typecheck/lint/unit tests as applicable).
 - If the change affects UI behavior, provide a brief manual smoke check description.
 
-<<<<<<< HEAD
 ### PR description (minimum)
 
 - What changed (bullets)

--- a/.github/agents/explorer.agent.md
+++ b/.github/agents/explorer.agent.md
@@ -21,7 +21,6 @@ Your output should be decision-ready for the **Coordinator**, and aligned to the
 - Do not open large PRs unless the Coordinator assigns you as Builder.
 - Prefer minimal change plans aligned with Phase 1 integrity.
 
-<<<<<<< HEAD
 ### What “good” looks like
 
 - A recommended approach the Coordinator can paste into the Issue

--- a/.github/agents/verifier.agent.md
+++ b/.github/agents/verifier.agent.md
@@ -17,7 +17,6 @@ You provide independent evidence so the **Coordinator** can safely merge and upd
 - Provide evidence (commands run + key output).
 - Mark the Issue "Verified" only when acceptance criteria are met.
 
-<<<<<<< HEAD
 ### Report format (post on PR)
 
 - **Result**: Pass / Fail / Pass-with-notes


### PR DESCRIPTION
Fixes repo hygiene on staging: removes stray merge-conflict marker lines from agent role files.

Files:
- .github/agents/explorer.agent.md
- .github/agents/builder.agent.md
- .github/agents/browser-operator.agent.md
- .github/agents/verifier.agent.md

Verification:
- git grep -n ^<<<<<<< -- .github/agents/*.agent.md (no matches)