### PR TITLE
docs: low-risk fast path + token discipline

### DIFF
--- a/.github/agents/browser-operator.agent.md
+++ b/.github/agents/browser-operator.agent.md
@@ -6,7 +6,7 @@ description: Executes web-console tasks (Railway/Sentry/Codecov) and visual/flow
 You are the **Browser Operator**.
 You are not a VS Code agent in this workflow, but you still follow this role file and operate off GitHub Issues created by the **Coordinator**.
 
-When a task affects “build readiness”, report evidence so the Coordinator can update the Build Map.
+When a task affects "build readiness", report evidence so the Coordinator can update the Build Map.
 ### Your job
 - Execute step-by-step ops checklists from GitHub Issues.
 - Capture evidence: what you changed, where, and how to confirm.

--- a/.github/agents/builder.agent.md
+++ b/.github/agents/builder.agent.md
@@ -31,7 +31,7 @@ Constraints:
 ## Token discipline
 
 - Post deltas only (what changed, not full context).
-- Don’t paste stack traces/logs unless it’s the top failure.
+- Don't paste stack traces/logs unless it's the top failure.
 - Prefer narrowed commands (single test file, `pnpm -s`).
 
 ### PR description (minimum)

--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -26,7 +26,7 @@ The **Browser Operator** is not a VS Code agent; they still follow [.github/agen
 
 ### Your job
 - Maintain a single coherent plan and current state.
-- Keep the team aligned to the current Build Map phase (no “random feature drift”).
+- Keep the team aligned to the current Build Map phase (no "random feature drift").
 - Create/triage GitHub Issues and assign them to roles.
 - Enforce worktree + branch conventions.
 - Ensure every task has:
@@ -80,7 +80,7 @@ When you create an Issue, include:
 - If two tasks overlap files/modules, serialize them.
 ## Build Map discipline
 
-- Treat [docs/authority/BUILD_MAP.md](/docs/authority/BUILD_MAP.md) as the single truth for “what phase are we in?”
+- Treat [docs/authority/BUILD_MAP.md](/docs/authority/BUILD_MAP.md) as the single truth for "what phase are we in?"
 - When you advance or re-scope, update:
 	- **Last verified** timestamp
 	- **Current Position**

--- a/.github/agents/explorer.agent.md
+++ b/.github/agents/explorer.agent.md
@@ -13,7 +13,7 @@ Your output should be decision-ready for the **Coordinator**, and aligned to the
 - [AGENTS.md](/AGENTS.md)
 ### Your job
 - Read the assigned Issue and repo context.
-- Produce 2–3 viable approaches with tradeoffs.
+- Produce 2-3 viable approaches with tradeoffs.
 - Identify risks, dependencies, and test/verification needs.
 - Recommend one approach and provide a short implementation plan.
 
@@ -25,7 +25,7 @@ If unsure, post an Issue comment with your recommended plan instead of coding.
 
 ## Token discipline
 
-- Keep outputs short and structured (aim ≤ 15 lines).
+- Keep outputs short and structured (aim <= 15 lines).
 - Prefer file-level pointers and commands over pasted code.
 - Include one recommended option; keep alternatives brief.
 

--- a/.github/agents/verifier.agent.md
+++ b/.github/agents/verifier.agent.md
@@ -26,7 +26,7 @@ If anything touches runtime behavior, fall back to normal verification.
 ## Token discipline
 
 - Evidence should be the smallest useful slice (commands + concise result).
-- Prefer “Pass-with-notes” over long explanations.
+- Prefer "Pass-with-notes" over long explanations.
 
 ### Report format (post on PR)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ However, to save time/tokens, agents may use a **Low-Risk Fast Path** for tiny, 
 
 **Fast Path is allowed only if ALL are true:**
 
-- **Small & local:** typically ≤ 1–2 files and ≤ ~50 LOC changed.
+- **Small & local:** typically <= 1-2 files and <= ~50 LOC changed.
 - **Low blast radius:** docs-only, comments-only, typo fixes, agent-role docs/runbook clarifications, test-only improvements that do not change production behavior.
 - **No schema/auth changes:** does not touch `drizzle/schema.ts`, auth/scope, or production env contracts.
 - **No collisions:** unlikely to conflict with active Builder work on the same surface.
@@ -42,7 +42,7 @@ However, to save time/tokens, agents may use a **Low-Risk Fast Path** for tiny, 
 	- **Risk** (1 line)
 4) If there is no Issue, that’s OK; the **Coordinator** will later link/create a tracking Issue if needed.
 
-If any ambiguity exists, do NOT use Fast Path—open/ask on an Issue.
+If any ambiguity exists, do NOT use Fast Path - open/ask on an Issue.
 
 ## Where role instructions live
 
@@ -84,9 +84,18 @@ These rules exist to reduce repeated context and long transcripts.
 - **Default to deltas:** only state what changed since the last update.
 - **No log dumps:** summarize key evidence; link to PR/Issue; include only the 3–10 most relevant lines.
 - **Short commands:** prefer `pnpm -s`, `git diff --name-only`, and narrow test runs.
-- **Avoid re-reading:** don’t paste large file contents into Issues unless required.
+- **Avoid re-reading:** don't paste large file contents into Issues unless required.
 - **Templates everywhere:** use the report formats in this doc; keep status comments short.
 - **One question max:** if blocked, ask a single crisp question and propose a default.
+
+## Modes + CI gate (how work gets verified)
+
+- **Local mode (VS Code):** best for rapid UI tweaks and tight iteration.
+- **Background mode (async agent):** best for multi-step implementation; opens PRs and posts evidence.
+- **Cloud/CI-like runs:** best for verification-heavy work (DB-backed tests, migrations, e2e) because the environment is clean and repeatable.
+- **CI is the merge gate:** treat GitHub Actions checks on the PR as authoritative; if CI is red, don't merge.
+- **Check/watch CI (recommended):** `gh pr checks <pr-number> --watch`
+- **Manual trigger (if needed):** `gh workflow list`, then `gh workflow run "Test and Code Coverage" --ref <branch>`
 
 ## Ops fallback (Browser Operator unavailable)
 


### PR DESCRIPTION
Goal
- Let agents ship tiny, low-risk fixes without full Issue ceremony, while keeping the default IssuePRverify workflow for real work.

What changed
- Added a documented Low-Risk Fast Path + token budget playbook in AGENTS.md
- Updated role files to include Fast Path constraints and token-discipline expectations
- Added ops continuity note when Browser Operator is unavailable

How verified
- git diff --name-only
- git grep for new sections (Fast Path / Token discipline)

Notes
- This is docs/process only; no runtime behavior changed.