### PR TITLE
ci: Copilot auto-handoff label workflow

### DIFF
--- a/.github/workflows/copilot-auto-handoff.yml
+++ b/.github/workflows/copilot-auto-handoff.yml
@@ -1,0 +1,57 @@
+name: Copilot auto-handoff
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  assign_to_copilot:
+    name: Assign to Copilot
+    if: github.event.label.name == 'agent:copilot'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Assign issue to Copilot coding agent
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+
+            const assignees = (context.payload.issue.assignees ?? []).map(a => a.login);
+            if (assignees.includes('copilot-swe-agent[bot]') || assignees.includes('copilot-swe-agent')) {
+              core.info('Copilot is already assigned.');
+              return;
+            }
+
+            const target_repo = `${owner}/${repo}`;
+
+            await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
+              owner,
+              repo,
+              issue_number,
+              assignees: ['copilot-swe-agent[bot]'],
+              agent_assignment: {
+                target_repo,
+                base_branch: 'staging',
+                custom_instructions: [
+                  'Work from the `staging` branch and open a PR targeting `staging`.',
+                  'Follow repository instructions in AGENTS.md and docs/authority/BUILD_MAP.md.',
+                  'Keep the diff small and scoped to the issue.',
+                  'Run the cheapest relevant checks (e.g. `pnpm check`, `pnpm test`) and report evidence in the PR.'
+                ].join('\n')
+              },
+              headers: {
+                'Accept': 'application/vnd.github+json',
+                'X-GitHub-Api-Version': '2022-11-28'
+              }
+            });
+
+            core.info('Assigned issue to copilot-swe-agent[bot].');

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,17 @@ These rules exist to reduce repeated context and long transcripts.
 - **Check/watch CI (recommended):** `gh pr checks <pr-number> --watch`
 - **Manual trigger (if needed):** `gh workflow list`, then `gh workflow run "Test and Code Coverage" --ref <branch>`
 
+## Copilot auto-handoff (Issue label → Copilot PR)
+
+This repo supports an optional automation: label an Issue with `agent:copilot` and GitHub Actions will assign the Issue to `copilot-swe-agent[bot]`.
+
+- Workflow: [.github/workflows/copilot-auto-handoff.yml](.github/workflows/copilot-auto-handoff.yml)
+- Trigger label: `agent:copilot`
+- Required secret: `COPILOT_ASSIGN_TOKEN` (a user token with permission to update Issues; see GitHub docs for Copilot assignment requirements)
+- Base branch: the workflow requests Copilot to work from `staging` and open a PR targeting `staging`
+
+Important: GitHub evaluates `issues.*` workflows from the repository's default branch. Ensure the workflow exists on the default branch (or set the default branch to `staging`) for the label trigger to work.
+
 ## Ops fallback (Browser Operator unavailable)
 
 If the Browser/Browser Operator is unavailable and staging is blocked by a console setting (Railway/Sentry/Codecov):


### PR DESCRIPTION
Why (#142): Enable an Issue label to auto-assign the Issue to GitHub Copilot coding agent and request work from staging.

What changed:
- Add workflow .github/workflows/copilot-auto-handoff.yml (triggers on issues.labeled for gent:copilot).
- Document setup + required secret in AGENTS.md.

How verified:
- git diff --name-only, git diff --check

Setup note:
- GitHub evaluates issues.* workflows from the repository *default branch*. If default is still main, cherry-pick this workflow into main (or change default branch to staging) so the label trigger executes.