### PR TITLE
chore: codespaces devcontainer + dual-token copilot handoff

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,20 @@
+# Codespaces / Devcontainer
+
+This repo supports GitHub Codespaces via a devcontainer.
+
+## What you get
+
+- Node + pnpm inside the `app` container
+- MySQL 8 inside the `mysql` container
+- Ports forwarded: `5173` (Vite), `3000` (server), `3306` (MySQL)
+
+## First-time setup
+
+The container runs `pnpm install` on create.
+
+Suggested next steps inside the container:
+
+- `pnpm dev`
+- `pnpm db:push:yes` (sync schema to dev DB)
+
+If you need Codespaces CLI access locally, ensure your `gh` token includes the `codespace` scope.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "CMC Go (Codespaces)",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "forwardPorts": [5173, 3000, 3306],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "GitHub.copilot",
+        "GitHub.copilot-chat",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+  "postCreateCommand": "corepack enable && pnpm install"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm
+    volumes:
+      - ..:/workspaces/CMC-Go:cached
+    command: sleep infinity
+    environment:
+      # App/DB connection
+      MYSQL_HOST: mysql
+      MYSQL_PORT: '3306'
+      MYSQL_USER: cmc
+      MYSQL_PASSWORD: cmc
+      MYSQL_DATABASE: cmc
+      DATABASE_URL: mysql://cmc:cmc@mysql:3306/cmc
+      # Typical local dev defaults
+      NODE_ENV: development
+    depends_on:
+      - mysql
+
+  mysql:
+    image: mysql:8.0
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: cmc
+      MYSQL_USER: cmc
+      MYSQL_PASSWORD: cmc
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - '3306:3306'
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  mysql-data:

--- a/.github/workflows/copilot-auto-handoff.yml
+++ b/.github/workflows/copilot-auto-handoff.yml
@@ -8,9 +8,9 @@ permissions:
   contents: read
 
 jobs:
-  assign_to_copilot:
-    name: Assign to Copilot
-    if: github.event.label.name == 'agent:copilot'
+  assign_to_copilot_tl:
+    name: Assign to Copilot (TL token)
+    if: github.event.label.name == 'agent:copilot' || github.event.label.name == 'agent:copilot-tl'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -19,7 +19,7 @@ jobs:
       - name: Assign issue to Copilot coding agent
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN_TL || secrets.COPILOT_ASSIGN_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -43,7 +43,57 @@ jobs:
                 base_branch: 'staging',
                 custom_instructions: [
                   'Work from the `staging` branch and open a PR targeting `staging`.',
-                  'Follow repository instructions in AGENTS.md and docs/authority/BUILD_MAP.md.',
+                  'Follow repository instructions in AGENTS.md and docs/agents/authority/CMC_OVERVIEW.md.',
+                  'Use docs/agents/runbook/RUNBOOK_INDEX.md for operational procedures.',
+                  'Keep the diff small and scoped to the issue.',
+                  'Run the cheapest relevant checks (e.g. `pnpm check`, `pnpm test`) and report evidence in the PR.'
+                ].join('\n')
+              },
+              headers: {
+                'Accept': 'application/vnd.github+json',
+                'X-GitHub-Api-Version': '2022-11-28'
+              }
+            });
+
+            core.info('Assigned issue to copilot-swe-agent[bot].');
+
+  assign_to_copilot_swe:
+    name: Assign to Copilot (SWE token)
+    if: github.event.label.name == 'agent:copilot-swe'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Assign issue to Copilot coding agent
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN_SWE || secrets.COPILOT_ASSIGN_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+
+            const assignees = (context.payload.issue.assignees ?? []).map(a => a.login);
+            if (assignees.includes('copilot-swe-agent[bot]') || assignees.includes('copilot-swe-agent')) {
+              core.info('Copilot is already assigned.');
+              return;
+            }
+
+            const target_repo = `${owner}/${repo}`;
+
+            await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
+              owner,
+              repo,
+              issue_number,
+              assignees: ['copilot-swe-agent[bot]'],
+              agent_assignment: {
+                target_repo,
+                base_branch: 'staging',
+                custom_instructions: [
+                  'Work from the `staging` branch and open a PR targeting `staging`.',
+                  'Follow repository instructions in AGENTS.md and docs/agents/authority/CMC_OVERVIEW.md.',
+                  'Use docs/agents/runbook/RUNBOOK_INDEX.md for operational procedures.',
                   'Keep the diff small and scoped to the issue.',
                   'Run the cheapest relevant checks (e.g. `pnpm check`, `pnpm test`) and report evidence in the PR.'
                 ].join('\n')


### PR DESCRIPTION
﻿Why
- Make Codespaces a first-class dev option (Node+pnpm + MySQL)
- Route Copilot auto-handoff to the right secret/token via labels

What changed
- Added .devcontainer (docker-compose: app + mysql)
- Updated .github/workflows/copilot-auto-handoff.yml:
  - agent:copilot, agent:copilot-tl -> COPILOT_ASSIGN_TOKEN_TL (fallback to COPILOT_ASSIGN_TOKEN)
  - agent:copilot-swe -> COPILOT_ASSIGN_TOKEN_SWE (fallback to COPILOT_ASSIGN_TOKEN)
  - Updated instruction doc paths (AGENTS.md + docs/agents/authority/CMC_OVERVIEW.md)

How verified
- Local: git status clean; no runtime verification yet (relies on Actions)

Notes
- If you want Codespaces visibility via CLI locally: run `gh auth refresh -h github.com -s codespace`.
