### PR TITLE
chore: codespaces devcontainer + dual-token copilot handoff

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,27 @@
+# Codespaces / Dev Container
+
+This repo supports GitHub Codespaces via the devcontainer in this folder.
+
+## What you get
+
+- Node + pnpm (via corepack)
+- MySQL 8 running as a sibling container (`db`)
+- Environment variables pre-set for the server DB connector (`DATABASE_URL` and `MYSQL_*`)
+
+## First-time usage
+
+1) Open the repo in a Codespace.
+2) Wait for `pnpm install` to finish.
+3) Start dev:
+
+- `pnpm dev`
+
+If you need schema sync/seed:
+
+- `pnpm db:push:yes`
+- `pnpm db:seed`
+
+## Notes
+
+- The MySQL data is persisted in a named docker volume (`mysql-data`).
+- Ports 5173/3000/3001 are forwarded automatically.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,48 @@
+{
+  "name": "CMC Go (Codespaces)",
+  "dockerComposeFile": [
+    "docker-compose.yml"
+  ],
+  "service": "app",
+  "workspaceFolder": "/workspaces/cmc-go",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "username": "node"
+    }
+  },
+  "postCreateCommand": "corepack enable && pnpm --version && pnpm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "GitHub.copilot",
+        "GitHub.copilot-chat",
+        "ms-azuretools.vscode-docker",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+  "forwardPorts": [
+    5173,
+    3000,
+    3001
+  ],
+  "portsAttributes": {
+    "5173": {
+      "label": "Vite dev server",
+      "onAutoForward": "openBrowser"
+    },
+    "3000": {
+      "label": "Server (if 3000)",
+      "onAutoForward": "notify"
+    },
+    "3001": {
+      "label": "Server (if 3001)",
+      "onAutoForward": "notify"
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.8"
+
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm
+    volumes:
+      - ..:/workspaces/cmc-go:cached
+    command: sleep infinity
+    environment:
+      # App DB config (server/db.ts supports DATABASE_URL or MYSQL_* vars)
+      MYSQL_HOST: db
+      MYSQL_PORT: "3306"
+      MYSQL_USER: cmc
+      MYSQL_PASSWORD: cmc
+      MYSQL_DATABASE: cmc_go
+      DATABASE_URL: mysql://cmc:cmc@db:3306/cmc_go
+    depends_on:
+      - db
+
+  db:
+    image: mysql:8.0
+    restart: unless-stopped
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: cmc_go
+      MYSQL_USER: cmc
+      MYSQL_PASSWORD: cmc
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  mysql-data:

--- a/.github/workflows/copilot-auto-handoff.yml
+++ b/.github/workflows/copilot-auto-handoff.yml
@@ -8,9 +8,9 @@ permissions:
   contents: read
 
 jobs:
-  assign_to_copilot:
-    name: Assign to Copilot
-    if: github.event.label.name == 'agent:copilot'
+  assign_to_copilot_tl:
+    name: Assign to Copilot (TL token)
+    if: github.event.label.name == 'agent:copilot' || github.event.label.name == 'agent:copilot-tl'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -19,7 +19,7 @@ jobs:
       - name: Assign issue to Copilot coding agent
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN_TL }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -43,7 +43,55 @@ jobs:
                 base_branch: 'staging',
                 custom_instructions: [
                   'Work from the `staging` branch and open a PR targeting `staging`.',
-                  'Follow repository instructions in AGENTS.md and docs/authority/BUILD_MAP.md.',
+                  'Follow repository instructions in AGENTS.md and docs/agents/authority/CMC_OVERVIEW.md.',
+                  'Keep the diff small and scoped to the issue.',
+                  'Run the cheapest relevant checks (e.g. `pnpm check`, `pnpm test`) and report evidence in the PR.'
+                ].join('\n')
+              },
+              headers: {
+                'Accept': 'application/vnd.github+json',
+                'X-GitHub-Api-Version': '2022-11-28'
+              }
+            });
+
+            core.info('Assigned issue to copilot-swe-agent[bot].');
+
+  assign_to_copilot_swe:
+    name: Assign to Copilot (SWE token)
+    if: github.event.label.name == 'agent:copilot-swe'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Assign issue to Copilot coding agent
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN_SWE }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+
+            const assignees = (context.payload.issue.assignees ?? []).map(a => a.login);
+            if (assignees.includes('copilot-swe-agent[bot]') || assignees.includes('copilot-swe-agent')) {
+              core.info('Copilot is already assigned.');
+              return;
+            }
+
+            const target_repo = `${owner}/${repo}`;
+
+            await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
+              owner,
+              repo,
+              issue_number,
+              assignees: ['copilot-swe-agent[bot]'],
+              agent_assignment: {
+                target_repo,
+                base_branch: 'staging',
+                custom_instructions: [
+                  'Work from the `staging` branch and open a PR targeting `staging`.',
+                  'Follow repository instructions in AGENTS.md and docs/agents/authority/CMC_OVERVIEW.md.',
                   'Keep the diff small and scoped to the issue.',
                   'Run the cheapest relevant checks (e.g. `pnpm check`, `pnpm test`) and report evidence in the PR.'
                 ].join('\n')

--- a/scripts/agent-login-gh.ps1
+++ b/scripts/agent-login-gh.ps1
@@ -1,0 +1,27 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('alpha-tech-lead','software-engineer-agent')]
+  [string]$Account
+)
+
+$ErrorActionPreference = 'Stop'
+
+$base = $env:USERPROFILE
+$configDir = if ($Account -eq 'alpha-tech-lead') {
+  Join-Path $base '.gh-alpha-tech-lead'
+} else {
+  Join-Path $base '.gh-software-engineer-agent'
+}
+
+$env:GH_CONFIG_DIR = $configDir
+$env:GH_PAGER = 'cat'
+
+Write-Host "Using GH_CONFIG_DIR=$configDir" -ForegroundColor Cyan
+Write-Host "A browser/device flow will open; sign in as $Account" -ForegroundColor Cyan
+
+& gh auth login -h github.com -p https --web
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+& gh auth status -h github.com
+exit $LASTEXITCODE

--- a/scripts/gh-as.ps1
+++ b/scripts/gh-as.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('alpha-tech-lead','software-engineer-agent')]
+  [string]$Account,
+
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$GhArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+$base = $env:USERPROFILE
+$map = @{
+  'alpha-tech-lead' = Join-Path $base '.gh-alpha-tech-lead'
+  'software-engineer-agent' = Join-Path $base '.gh-software-engineer-agent'
+}
+
+$env:GH_CONFIG_DIR = $map[$Account]
+$env:GH_PAGER = 'cat'
+
+& gh @GhArgs
+exit $LASTEXITCODE

--- a/scripts/git-credential-gh.ps1
+++ b/scripts/git-credential-gh.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ConfigDir,
+
+  [string]$Host = 'github.com',
+
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$Args
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $ConfigDir)) {
+  New-Item -ItemType Directory -Force -Path $ConfigDir | Out-Null
+}
+
+$stdin = [Console]::In.ReadToEnd()
+
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = 'gh'
+$psi.Arguments = ('auth git-credential -h ' + $Host + ' ' + ($Args -join ' ')).Trim()
+$psi.RedirectStandardInput = $true
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow = $true
+$psi.EnvironmentVariables['GH_CONFIG_DIR'] = $ConfigDir
+$psi.EnvironmentVariables['GH_PAGER'] = 'cat'
+
+$p = New-Object System.Diagnostics.Process
+$p.StartInfo = $psi
+$null = $p.Start()
+
+if ($stdin) {
+  $p.StandardInput.Write($stdin)
+}
+$p.StandardInput.Close()
+
+$out = $p.StandardOutput.ReadToEnd()
+$err = $p.StandardError.ReadToEnd()
+$p.WaitForExit()
+
+if ($out) { [Console]::Out.Write($out) }
+if ($err) { [Console]::Error.Write($err) }
+
+exit $p.ExitCode

--- a/scripts/set-gh-secret.ps1
+++ b/scripts/set-gh-secret.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('COPILOT_ASSIGN_TOKEN_TL','COPILOT_ASSIGN_TOKEN_SWE')]
+  [string]$SecretName
+)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Paste the token for $SecretName and press Enter:" -ForegroundColor Cyan
+$token = Read-Host
+
+$repo = 'sirjamesoffordii/CMC-Go'
+
+$env:GH_PAGER = 'cat'
+
+& gh secret set $SecretName --body $token --repo $repo
+if ($LASTEXITCODE -eq 0) {
+  Write-Host "Secret $SecretName set successfully." -ForegroundColor Green
+} else {
+  Write-Host "Failed to set secret $SecretName." -ForegroundColor Red
+  exit $LASTEXITCODE
+}

--- a/scripts/setup-agent-identities.ps1
+++ b/scripts/setup-agent-identities.ps1
@@ -1,0 +1,43 @@
+[CmdletBinding()]
+param(
+  [string]$Repo = 'C:\Dev\CMC Go'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function RunGit {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Args
+  )
+
+  & git @Args
+  if ($LASTEXITCODE -ne 0) {
+    throw ("git failed (exit $LASTEXITCODE): git " + ($Args -join ' '))
+  }
+}
+
+$tl = Join-Path $Repo '.worktrees\wt-agent-tl'
+$swe = Join-Path $Repo '.worktrees\wt-agent-swe'
+
+$helperTl = '!powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:/Dev/CMC Go/scripts/git-credential-gh.ps1" -ConfigDir "C:/Users/sirja/.gh-alpha-tech-lead"'
+$helperSwe = '!powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:/Dev/CMC Go/scripts/git-credential-gh.ps1" -ConfigDir "C:/Users/sirja/.gh-software-engineer-agent"'
+
+if (-not (Test-Path -LiteralPath $Repo)) { throw "Missing repo path: $Repo" }
+if (-not (Test-Path -LiteralPath $tl)) { throw "Missing TL worktree: $tl" }
+if (-not (Test-Path -LiteralPath $swe)) { throw "Missing SWE worktree: $swe" }
+
+# Restore a sane default for the main repo config (shared across worktrees)
+RunGit -Args @('-C', $Repo, 'config', '--local', 'user.name', 'sirjamesoffordii')
+RunGit -Args @('-C', $Repo, 'config', '--local', 'user.email', 'sirjamesoffordii@users.noreply.github.com')
+
+# Worktree-specific identity + auth
+RunGit -Args @('-C', $tl, 'config', '--worktree', 'user.name', 'alpha-tech-lead')
+RunGit -Args @('-C', $tl, 'config', '--worktree', 'user.email', 'alpha-tech-lead@users.noreply.github.com')
+RunGit -Args @('-C', $tl, 'config', '--worktree', 'credential.helper', $helperTl)
+
+RunGit -Args @('-C', $swe, 'config', '--worktree', 'user.name', 'software-engineer-agent')
+RunGit -Args @('-C', $swe, 'config', '--worktree', 'user.email', 'software-engineer-agent@users.noreply.github.com')
+RunGit -Args @('-C', $swe, 'config', '--worktree', 'credential.helper', $helperSwe)
+
+Write-Host 'OK' -ForegroundColor Green


### PR DESCRIPTION
﻿Why
- Enable label-driven Copilot auto-handoff (TL vs SWE token) and provide a consistent Codespaces dev setup.

What changed
- Add .devcontainer (Node+pnpm + MySQL via docker-compose)
- Update copilot-auto-handoff workflow to use COPILOT_ASSIGN_TOKEN_TL for agent:copilot/agent:copilot-tl and COPILOT_ASSIGN_TOKEN_SWE for agent:copilot-swe
- Add helper scripts: scripts/agent-login-gh.ps1, scripts/gh-as.ps1, scripts/git-credential-gh.ps1, scripts/set-gh-secret.ps1, scripts/setup-agent-identities.ps1

How verified
- pnpm install
- pnpm check (exit 0)

Notes
- The workflow expects repo secrets COPILOT_ASSIGN_TOKEN_TL and COPILOT_ASSIGN_TOKEN_SWE to be set.
