### PR TITLE
docs(agents): align for hands-off autonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_task.md
+++ b/.github/ISSUE_TEMPLATE/feature_task.md
@@ -19,7 +19,24 @@ labels: ["status:ready"]
 
 ## Verify Level
 
-- L0 (self) | L1 (peer) | L2 (deep)
+Set PR labels (these are enforced by CI):
+
+- `verify:v0` (self)
+- `verify:v1` (peer approval required)
+- `verify:v2` (peer approval + evidence labels required)
+
+For `verify:v2`, also add evidence labels:
+
+- `evidence:db-or-ci`
+- `evidence:deployed-smoke`
+
+## Agent routing (optional)
+
+To trigger the GitHub-hosted Copilot agent, add one label:
+
+- `agent:copilot-swe` (implementation)
+- `agent:copilot-tl` (triage/coordination)
+- `agent:copilot` (defaults to TL token)
 
 ## Verification Steps
 Commands to run:

--- a/.github/README.md
+++ b/.github/README.md
@@ -2,6 +2,8 @@
 
 This folder contains (1) GitHub automation and (2) the **active** agent docs.
 
+These docs are written for agents. In a hands-off workflow the operator primarily labels Issues to route work and approves/merges PRs when gates pass.
+
 ## Mental model
 
 - Issue templates define *work intake*

--- a/.github/prompts/software-engineer.prompt.md
+++ b/.github/prompts/software-engineer.prompt.md
@@ -20,7 +20,9 @@ Working truth (Projects v2): https://github.com/users/sirjamesoffordii/projects/
 
 ## First move (always)
 1) Identify the Issue/PR and restate acceptance criteria.
-2) Confirm correct worktree (`wt-impl-*` or `wt-verify-*`).
+2) Confirm execution mode:
+	- Mode A (local VS Code agent): use a correct worktree (`wt-impl-*` or `wt-verify-*`).
+	- Mode B (GitHub-hosted agent): branch-only; no worktrees.
 
 ## Operating stance
 - Default: implement small diffs with evidence (or verify with a verdict).

--- a/.github/prompts/tech-lead.prompt.md
+++ b/.github/prompts/tech-lead.prompt.md
@@ -19,7 +19,9 @@ Skim in this order:
 Working truth (Projects v2): https://github.com/users/sirjamesoffordii/projects/2
 
 ## First move (always)
-1) Sync to `origin/staging` and confirm a clean tree.
+1) Confirm execution mode:
+	- Mode A (local VS Code agent): sync to `origin/staging` and confirm a clean tree.
+	- Mode B (GitHub-hosted agent): operate branch-only; ensure the PR targets `staging`.
 2) Pick the active work item (Issue/PR/Project card).
 
 ## Default priorities (flexible)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # CMC Go — Agent Operating Manual
 
-This is the **single source of truth** for how humans + agents work in this repo.
+This is the **single source of truth** for how agents operate in this repo, and what the operator does (label/approve/merge) in a hands-off workflow.
 
 ## Read-first
 
@@ -23,10 +23,35 @@ Working truth (Projects v2): https://github.com/users/sirjamesoffordii/projects/
 ## Operating principles
 
 - **Issues/PRs are the task bus.** Decisions + evidence live there.
-- **Worktrees required.** No direct work on `staging`.
+- **Execution mode must be explicit.** Local agents use worktrees; GitHub-hosted agents are branch-only.
 - **Small diffs.** Keep changes reviewable.
 - **No secrets.** `.env*` stays local; use platform/GitHub secrets.
 - **Keep looping.** Take the next best safe step until Done.
+
+## Execution modes (critical)
+
+Agents may run in one of two execution modes. All instructions below apply, but the repo hygiene mechanics differ.
+
+### Mode A — Local VS Code agent (runs on the operator machine)
+
+- **Worktrees are required.** Never work directly on `staging`.
+- Use worktrees to isolate implementation and verification.
+- Only `wt-main` is allowed to run `pnpm dev`.
+
+### Mode B — GitHub-hosted Copilot coding agent (cloud)
+
+- **Worktrees do not exist.** Operate branch-only.
+- Always base work on `staging` and open PRs targeting `staging`.
+- Do not run long-lived servers.
+
+## Operator role (hands-off)
+
+The operator is not expected to write code.
+
+- Creates Issues using templates.
+- Applies labels to route work (e.g. `agent:copilot-swe`, `verify:v1`).
+- Approves/merges PRs when the verification gate passes.
+- Performs console-only steps when 2FA/login blocks automation (Sentry/Railway/etc.).
 
 ## Standard workflow
 
@@ -56,6 +81,8 @@ Work happens in isolated worktrees to prevent collisions.
 - `wt-impl-<issue#>-<slug>` — implementation work
 - `wt-verify-<pr#>-<slug>` — verification work (no implementation)
 - `wt-docs-<YYYY-MM-DD>` — docs-only changes
+
+Note: this policy applies to **Mode A (local)** only. In **Mode B (cloud)** the equivalent is simply “one branch per task; never commit on `staging`.”
 
 ## Claiming work (collision prevention)
 


### PR DESCRIPTION
Why
- Make the agent docs match the intended hands-off autonomous workflow.

What changed
- Clarifies execution modes: local VS Code agent (worktrees) vs GitHub-hosted agent (branch-only).
- Aligns verification terminology in the Issue template with CI-enforced labels (verify:v0/v1/v2 + evidence labels).
- Updates TL/SWE prompts to choose execution mode explicitly.

How verified
- Docs-only change; validated for consistency against existing workflows (copilot-auto-handoff.yml, verification-gate.yml).