### PR TITLE
docs(agents): harvest archived role templates into TL/SWE

### DIFF
--- a/.github/_unused/agents/browser-operator.archived.md
+++ b/.github/_unused/agents/browser-operator.archived.md
@@ -6,11 +6,7 @@ description: Executes web-console tasks (Railway/Sentry/Codecov) and visual/flow
 You are the **Browser Operator**.
 You are not a VS Code agent in this workflow, but you still follow this role file and operate off GitHub Issues triaged by **TL**.
 
-<<<<<<< HEAD
 When a task affects "build readiness", report evidence so TL can update status and gates.
-=======
-When a task affects "build readiness", report evidence so the Coordinator can update the Build Map.
->>>>>>> cf15485 (agent(docs): add CI gate + normalize punctuation)
 ### Your job
 - Execute step-by-step ops checklists from GitHub Issues.
 - Capture evidence: what you changed, where, and how to confirm.

--- a/.github/agents/software-engineer.agent.md
+++ b/.github/agents/software-engineer.agent.md
@@ -20,6 +20,8 @@ Working truth:
 - Prefer surgical fixes over refactors.
 - Always include evidence (commands run + results) in the PR.
 
+Use the PR description + verdict templates in `AGENTS.md`.
+
 3) Keep momentum
 - If you’re working solo or the work item is missing structure, tighten the Issue (AC/verification), update the Project status, and then proceed.
 
@@ -34,3 +36,4 @@ Working truth:
 - Confirm you’re in the right worktree (`wt-impl-*` or `wt-verify-*`)
 - Keep the diff minimal and scoped
 - Post evidence (commands + results) and a clear verdict when verifying
+- If blocked: post one A/B/C escalation comment (see `AGENTS.md`), then continue parallel-safe work

--- a/.github/agents/tech-lead.agent.md
+++ b/.github/agents/tech-lead.agent.md
@@ -27,6 +27,8 @@ Working truth:
 4) Escalate decisions cleanly
 - If a product decision is required, ask one crisp A/B/C question in the Issue/PR thread.
 
+Use the escalation template in `AGENTS.md` to keep this consistent.
+
 5) Do the highest-leverage next step
 - Default is coordination, but you may implement or verify when that is the fastest path to unblock progress.
 
@@ -42,3 +44,4 @@ Working truth:
 - Ensure it has AC + a verification checklist
 - Route `status:verify` items first
 - Hand off implementation to SWE when executable
+- If blocked: post one A/B/C escalation comment, then continue parallel-safe work

--- a/.github/prompts/loop.prompt.md
+++ b/.github/prompts/loop.prompt.md
@@ -22,6 +22,6 @@ Token usage (GitHub automation):
 - If GitHub automation requires a token, use an operator-provided token ephemerally via `$env:GITHUB_TOKEN` (secure prompt if needed). Never print/log tokens, never write them to files, and clear the env var after use.
 
 If Blocked:
-- Post a single escalation comment with a concrete A/B/C decision request + evidence.
+- Post a single escalation comment with a concrete A/B/C decision request + evidence (use the template in `AGENTS.md`).
 - Immediately continue with the next best parallel work that does not require the decision.
 - If there is truly nothing safe to do in parallel, wait (stay in loop) and re-check the Issue thread for a Coordinator response.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,33 @@ Post updates in Issues/PRs using:
 - **How verified:** commands run + brief results
 - **Notes/Risks:** anything a reviewer should know
 
+## Escalation comment (copy/paste)
+
+When blocked, post **one** decision request (A/B/C) and keep moving.
+
+- **Status:** Blocked
+- **Decision needed:** <one sentence>
+- **Why it matters:** <one sentence>
+- **Options:** A) … / B) … / C) …
+- **Recommended default (if no response by <time>):** <A/B/C>
+- **Evidence:** <links / 3–10 key lines>
+- **Parallel work I will do now:** <short list>
+
+## PR description (minimum)
+
+- **Why:** link to Issue
+- **What changed:** bullets
+- **How verified:** commands + results
+- **Risk:** low/med/high + why
+
+## Verification verdict (minimum)
+
+When verifying a PR, post:
+
+- **Result:** Pass / Pass-with-notes / Fail
+- **Evidence:** commands + key output
+- **Notes/Risks:** gaps, flakiness, edge cases
+
 ## Low-risk fast path (docs/tiny fixes)
 
 Allowed only when all are true:


### PR DESCRIPTION
**Goal**\nHarvest the best reusable ops templates from archived role docs into the active TL/SWE + AGENTS surfaces, without reviving archived roles as active policy.\n\n**What changed**\n- Add copy/paste templates to AGENTS.md: escalation comment, PR description minimum, verification verdict minimum\n- Wire TL/SWE role docs + loop prompt to point at the new templates\n- Clean up a leftover merge-conflict marker block in an archived doc (browser-operator)\n\n**How verified**\n- Docs-only change; manual review + ensured no conflict markers remain (\\<\\<\\<\\<\\<\\<\\<).\n\n**Notes / Risk**\nLow risk; no runtime code changes.