### PR TITLE
docs(agents): add curated patterns surface + retrieval order

### DIFF
--- a/.github/agents/CMC_GO_PATTERNS.md
+++ b/.github/agents/CMC_GO_PATTERNS.md
@@ -1,0 +1,36 @@
+# CMC Go — Learned Patterns (Curated)
+
+Purpose: a **small, curated** set of reusable patterns + pitfalls for agents and humans.
+
+- This is not a runbook.
+- Keep this short: if it grows past ~20 items, prune or consolidate.
+- Prefer linking to the canonical source of truth (Issue/PR, code, schema) when possible.
+
+## When to use this
+
+Use this when you are:
+- repeating a failure pattern (tests, migrations, CI)
+- blocked on a repo-specific invariant (schema keys, map ids)
+- about to make a wide change and want known hazards
+
+If you need step-by-step operational procedures (Railway/Sentry/CI, etc.), consult the runbook index: `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md`.
+
+## Patterns
+
+### Invariants
+
+- `districts.id` (DistrictSlug) must match `client/public/map.svg` `<path id="...">` values (case-sensitive).
+- `people.personId` (varchar) is the cross-table/import key; preserve its semantics.
+- Status enum strings are fixed: `Yes`, `Maybe`, `No`, `Not Invited`.
+
+### Workflow / hygiene
+
+- Keep diffs small and scoped; prefer surgical fixes.
+- Use worktrees locally; never work directly on `staging`.
+- Put durable progress/evidence in the Issue/PR thread; chat is transient.
+
+### “Learning capture” rule
+
+If you solved a non-trivial problem, capture one reusable takeaway:
+- Add a short **Learning:** bullet to the Issue/PR comment alongside evidence.
+- If it’s general and likely to recur, distill it into this file (and keep it short).

--- a/.github/agents/software-engineer.agent.md
+++ b/.github/agents/software-engineer.agent.md
@@ -7,6 +7,8 @@ You are **Software Engineer (SWE)**.
 
 Common rules (worktrees, claims, evidence, verification levels) live in `AGENTS.md`. This file contains **SWE-specific** priorities.
 
+When stuck, consult `.github/agents/CMC_GO_PATTERNS.md` and the runbook index.
+
 Working truth:
 - Projects v2 board: https://github.com/users/sirjamesoffordii/projects/2
 

--- a/.github/agents/tech-lead.agent.md
+++ b/.github/agents/tech-lead.agent.md
@@ -7,6 +7,8 @@ You are **Tech Lead (TL)**.
 
 Common rules (worktrees, claims, evidence, verification levels) live in `AGENTS.md`. This file contains **TL-specific** priorities.
 
+When stuck, consult `.github/agents/CMC_GO_PATTERNS.md` and the runbook index.
+
 Working truth:
 - Projects v2 board: https://github.com/users/sirjamesoffordii/projects/2
 

--- a/.github/prompts/loop.prompt.md
+++ b/.github/prompts/loop.prompt.md
@@ -14,6 +14,12 @@ Always:
 - Keep token usage low: short updates, deltas, and links over log dumps.
 - If a runbook is needed, consult the archived index: `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md`.
 
+When uncertain or stuck, consult repo knowledge in this order:
+1) `AGENTS.md` (workflow + constraints)
+2) `.github/agents/CMC_GO_BRIEF.md` (product snapshot)
+3) `.github/agents/CMC_GO_PATTERNS.md` (curated pitfalls/patterns)
+4) `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md` (operational procedures)
+
 Operator interaction:
 - Keep chat minimal (status + blockers only).
 - All durable status/progress communication goes to the Issue/PR thread (shared truth).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,13 @@ Working truth (Projects v2): https://github.com/users/sirjamesoffordii/projects/
 - **No secrets.** `.env*` stays local; use platform/GitHub secrets.
 - **Keep looping.** Take the next best safe step until Done.
 
+## Knowledge surfaces (when to consult what)
+
+- **Policy + workflow:** `AGENTS.md` (this file)
+- **Product snapshot:** `.github/agents/CMC_GO_BRIEF.md`
+- **Curated learnings (pitfalls/patterns):** `.github/agents/CMC_GO_PATTERNS.md`
+- **Operational procedures (as-needed):** `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md`
+
 ## Execution modes (critical)
 
 Agents may run in one of two execution modes. All instructions below apply, but the repo hygiene mechanics differ.


### PR DESCRIPTION
﻿**Why**
Runbooks are great for step-by-step ops, but they arent a great learning surface because agents dont know when to consult them. This PR adds an explicit, curated patterns surface and wires a predictable retrieval order into the loop.

**What changed**
- Add a new curated knowledge surface: .github/agents/CMC_GO_PATTERNS.md
- Add an explicit Knowledge surfaces section to AGENTS.md
- Update the loop prompt + TL/SWE role docs with when/where to consult patterns vs runbooks

**How verified**
Docs-only; manual review.

**Risk**
Low.
