### PR TITLE
docs(agents): rename runbooks to operational procedures

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -14,19 +14,9 @@ These docs are written for agents. In a hands-off workflow the operator primaril
 
 ## Read-first (fast)
 
-- Policy: `AGENTS.md`
-- Product snapshot: `.github/agents/CMC_GO_BRIEF.md`
-- Role docs: `.github/agents/tech-lead.agent.md`, `.github/agents/software-engineer.agent.md`
-- Prompts: `.github/prompts/tech-lead.prompt.md`, `.github/prompts/software-engineer.prompt.md`, `.github/prompts/loop.prompt.md`
 
 When needed:
-- Archived runbooks index: `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md`
+ Archived operational procedures index: `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md`
 
 ## Contents
 
-- `.github/agents/` — active role + brief docs
-- `.github/prompts/` — activation prompts (TL/SWE/loop)
-- `.github/workflows/` — GitHub Actions
-- `.github/ISSUE_TEMPLATE/` — Issue templates
-- `.github/copilot-instructions.md` — extra Copilot guidance (kept short)
-- `.github/_unused/` — archived artifacts (not active policy)

--- a/.github/_unused/README.md
+++ b/.github/_unused/README.md
@@ -17,7 +17,7 @@ If something here becomes relevant again, move it back into an active location a
 - `.github/_unused/issue_templates/` — archived role-specific Issue templates
 - `.github/_unused/docs/agents/` — archived agent docs
 	- `legacy/` — historical docs (e.g., coordinator doctrine, old build map)
-	- `runbook/` — old runbooks
+	- `runbook/` — old operational procedures
 	- `old-brief/` — previous “overview/authority” style docs
 
 Note: archived docs may contain stale internal links; treat them as historical reference.

--- a/.github/_unused/docs/agents/README.md
+++ b/.github/_unused/docs/agents/README.md
@@ -11,7 +11,7 @@ This folder contains **legacy** agent documentation that is not part of the acti
 ## What’s inside
 
 - `legacy/` — historical doctrine (Coordinator, Build Map, old toolkits)
-- `runbook/` — old runbooks and operational notes
+- `runbook/` — old operational procedures and notes
 - `old-brief/` — previous “overview/authority” style docs
 
 If you want to revive any of this, move it into an active location and update links to match the current structure.

--- a/.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md
+++ b/.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md
@@ -1,6 +1,6 @@
-# Runbooks Index
+# Operational Procedures Index
 
-Single entrypoint for operational playbooks, setup/tooling references, and agent runbooks.
+Single entrypoint for operational playbooks, setup/tooling references, and agent operational procedures.
 
 ## Setup & workflow
 
@@ -36,9 +36,9 @@ Single entrypoint for operational playbooks, setup/tooling references, and agent
 
 - Ops change log: [ops-change-log.md](ops-change-log.md)
 
-## Agent runbooks
+## Agent operational procedures
 
-Agent-specific runbooks:
+Agent-specific operational procedures:
 
 - Evidence standard: [AGENT_EVIDENCE_STANDARD.md](AGENT_EVIDENCE_STANDARD.md)
 - Quick commands: [AGENT_QUICK_COMMANDS.md](AGENT_QUICK_COMMANDS.md)

--- a/.github/agents/CMC_GO_PATTERNS.md
+++ b/.github/agents/CMC_GO_PATTERNS.md
@@ -2,7 +2,7 @@
 
 Purpose: a **small, curated** set of reusable patterns + pitfalls for agents and humans.
 
-- This is not a runbook.
+- This is not an operational procedure.
 - Keep this short: if it grows past ~20 items, prune or consolidate.
 - Prefer linking to the canonical source of truth (Issue/PR, code, schema) when possible.
 
@@ -13,7 +13,7 @@ Use this when you are:
 - blocked on a repo-specific invariant (schema keys, map ids)
 - about to make a wide change and want known hazards
 
-If you need step-by-step operational procedures (Railway/Sentry/CI, etc.), consult the runbook index: `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md`.
+If you need step-by-step operational procedures (Railway/Sentry/CI, etc.), consult the operational procedures index: `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md`.
 
 ## Patterns
 

--- a/.github/agents/software-engineer.agent.md
+++ b/.github/agents/software-engineer.agent.md
@@ -7,7 +7,7 @@ You are **Software Engineer (SWE)**.
 
 Common rules (worktrees, claims, evidence, verification levels) live in `AGENTS.md`. This file contains **SWE-specific** priorities.
 
-When stuck, consult `.github/agents/CMC_GO_PATTERNS.md` and the runbook index.
+When stuck, consult `.github/agents/CMC_GO_PATTERNS.md` and the operational procedures index.
 
 Working truth:
 - Projects v2 board: https://github.com/users/sirjamesoffordii/projects/2

--- a/.github/agents/tech-lead.agent.md
+++ b/.github/agents/tech-lead.agent.md
@@ -7,7 +7,7 @@ You are **Tech Lead (TL)**.
 
 Common rules (worktrees, claims, evidence, verification levels) live in `AGENTS.md`. This file contains **TL-specific** priorities.
 
-When stuck, consult `.github/agents/CMC_GO_PATTERNS.md` and the runbook index.
+When stuck, consult `.github/agents/CMC_GO_PATTERNS.md` and the operational procedures index.
 
 Working truth:
 - Projects v2 board: https://github.com/users/sirjamesoffordii/projects/2

--- a/.github/prompts/loop.prompt.md
+++ b/.github/prompts/loop.prompt.md
@@ -12,7 +12,7 @@ Within an assigned Issue:
 Always:
 - Prefer the smallest safe next action.
 - Keep token usage low: short updates, deltas, and links over log dumps.
-- If a runbook is needed, consult the archived index: `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md`.
+- If operational procedures are needed, consult the archived index: `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md`.
 
 When uncertain or stuck, consult repo knowledge in this order:
 1) `AGENTS.md` (workflow + constraints)

--- a/.github/prompts/software-engineer.prompt.md
+++ b/.github/prompts/software-engineer.prompt.md
@@ -41,5 +41,5 @@ Working truth (Projects v2): https://github.com/users/sirjamesoffordii/projects/
 ## If blocked
 - Post one escalation comment (A/B/C options + recommended default), then continue safe parallel work or wait.
 
-## Runbooks (when needed)
-- For ops/env/CI/tooling questions, consult the archived runbook index: `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md`.
+## Operational procedures (when needed)
+- For ops/env/CI/tooling questions, consult the archived operational procedures index: `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,9 @@ temp/
 tmpclaude-*/
 tmpclaude-*
 
+# Local scratch / analysis clones
+_external/
+
 # Database
 data/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,7 @@ Post updates in Issues/PRs using:
 - **Branch/PR:** link
 - **What changed:** bullets
 - **How verified:** commands run + brief results
+- **Learning (optional):** one reusable takeaway to avoid repeating work
 - **Notes/Risks:** anything a reviewer should know
 
 ## Escalation comment (copy/paste)
@@ -172,9 +173,9 @@ Procedure:
 Label an Issue with `agent:copilot` (or `agent:copilot-tl`, `agent:copilot-swe`) to trigger:
 - [.github/workflows/copilot-auto-handoff.yml](.github/workflows/copilot-auto-handoff.yml)
 
-## Runbooks (when needed)
+## Operational procedures (when needed)
 
-Runbooks are not active policy, but are useful reference for ops/CI/tooling:
+Operational procedures are archived (not active policy), but are useful reference for ops/CI/tooling:
 
 - `.github/_unused/docs/agents/runbook/RUNBOOK_INDEX.md`
 


### PR DESCRIPTION
﻿**Why**
Make "runbooks" more discoverable by framing them as archived **operational procedures**, and make learning capture explicit in the standard evidence template. This keeps the autonomous loop predictable: patterns for reuse, procedures for step-by-step ops.

**What changed**
- Rename "Runbooks" references to "Operational procedures" (path unchanged)
- Add Learning (optional) bullet to the Evidence standard template in AGENTS.md
- Retitle the archived index to "Operational Procedures Index" (file path unchanged)
- Ignore local _external/ scratch area to prevent accidental commits

**How verified**
Docs-only; grep sanity for naming consistency.

**Risk**
Low.
