### PR TITLE
docs(devcontainer): local Windows setup + extensions

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -2,6 +2,8 @@
 
 This repo supports GitHub Codespaces via the devcontainer in this folder.
 
+It also works for local development on Windows/macOS/Linux as long as you have a Docker engine available.
+
 ## What you get
 
 - Node + pnpm (via corepack)
@@ -15,6 +17,31 @@ This repo supports GitHub Codespaces via the devcontainer in this folder.
 3) Start dev:
 
 - `pnpm dev`
+
+- `pnpm dev`
+
+## Local (Windows) — Dev Containers setup
+
+Prereqs:
+
+1) Install Docker Desktop for Windows.
+2) Ensure WSL2 is installed (a distro like Ubuntu is fine).
+3) In Docker Desktop Settings:
+	- Enable **Use the WSL 2 based engine**
+	- Enable **WSL integration** for your distro (e.g. `Ubuntu-24.04`)
+
+Quick verification (PowerShell):
+
+- `wsl -l -v`
+- `docker version`
+- `docker run --rm hello-world`
+
+Then in VS Code:
+
+1) Install the **Dev Containers** extension (`ms-vscode-remote.remote-containers`).
+2) Command Palette → **Dev Containers: Reopen in Container**.
+
+If you see prompts like “WSL not found”, it usually means Docker Desktop is not installed/running or WSL integration is not enabled for your distro.
 
 If you need schema sync/seed:
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,11 @@
         "GitHub.copilot-chat",
         "ms-azuretools.vscode-docker",
         "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode"
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "redhat.vscode-yaml",
+        "streetsidesoftware.code-spell-checker",
+        "ms-playwright.playwright"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "bash"


### PR DESCRIPTION
Why
- Dev Containers was triggering WSL/Docker confusion on Windows. Document the required local prerequisites and verification.

What changed
- Adds a Local (Windows) section to .devcontainer/README.md (Docker Desktop + WSL2 + verification commands).
- Expands devcontainer recommended extensions to match repo tooling (ESLint/Prettier/Tailwind/YAML/Playwright/etc.).

How verified
- Docs-only change; validated JSON syntax and kept changes scoped to .devcontainer.