### PR TITLE
chore(vscode): use org-specific Sentry URL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,8 @@
     "sentry.enabled": true,
     "sentry.organization": "sir-james-offord-ii",
     "sentry.projects": ["cmc-go-client"],
-    "sentry.serverUrl": "https://sentry.io",
-    "sentryAutoFix.sentryUrl": "https://sentry.io",
+    "sentry.serverUrl": "https://sir-james-offord-ii.sentry.io",
+    "sentryAutoFix.sentryUrl": "https://sir-james-offord-ii.sentry.io",
     "sentryAutoFix.projectSlugs": ["sir-james-offord-ii/cmc-go-client"],
     // Embedded preview: prefer Microsoft Edge Tools (not Simple Browser).
     "vscode-edge-devtools.defaultUrl": "http://127.0.0.1:3000",


### PR DESCRIPTION
Why: keep repo-tracked VS Code Sentry settings aligned to the organization-specific Sentry URL (not the generic https://sentry.io).

What changed:
- Update .vscode/settings.json Sentry URLs to https://sir-james-offord-ii.sentry.io for both the Issues viewer and Auto Fix extension.
- No tokens/secrets added.

How verified:
- CI checks green (test-and-coverage, verification-gate).