### PR TITLE
chore: remove handoff buttons

### DIFF
--- a/.github/agents/adr-generator.agent.md
+++ b/.github/agents/adr-generator.agent.md
@@ -2,11 +2,7 @@
 name: ADR Generator
 description: Creates and maintains Architectural Decision Records (ADRs) following the MADR format with AI-friendly structure.
 model: GPT-4.1
-handoffs:
-  - label: Back to TL
-    agent: Tech Lead (TL)
-    prompt: "ADR draft complete. Please review and approve."
-    send: false
+handoffs: []
 applyTo: "docs/decisions/**"
 tools: ["vscode", "read", "edit", "search", "web"]
 ---

--- a/.github/agents/software-engineer.agent.md
+++ b/.github/agents/software-engineer.agent.md
@@ -2,19 +2,7 @@
 name: Software Engineer (SWE)
 description: Implements small PRs with evidence, or performs peer verification with a clear verdict.
 model: GPT-5.2
-handoffs:
-  - label: Back to TL
-    agent: Tech Lead (TL)
-    prompt: "Implementation complete. Ready for review and merge."
-    send: true
-  - label: Request Tests
-    agent: Test Engineer
-    prompt: "Implementation needs test coverage. Please write tests for this feature."
-    send: true
-  - label: Escalate to TL
-    agent: Tech Lead (TL)
-    prompt: "Blocked on a decision. Need TL input on A/B/C options above."
-    send: false
+handoffs: []
 applyTo: "**"
 tools:
   [

--- a/.github/agents/tech-lead.agent.md
+++ b/.github/agents/tech-lead.agent.md
@@ -2,27 +2,7 @@
 name: Tech Lead (TL)
 description: "Project coordinator for CMC Go. Use when scanning project status, creating/refining Issues, or delegating work. Leads with coordination/triage. Can also verify, implement, explore, document."
 model: GPT-5.2
-handoffs:
-  - label: Implement with SWE
-    agent: Software Engineer (SWE)
-    prompt: "Implement the scope outlined above following the AC and verification steps. Issue is ready for implementation."
-    send: true
-  - label: Delegate to Cloud SWE
-    agent: Software Engineer (SWE)
-    prompt: "Apply label agent:copilot-swe to delegate this Issue to the cloud SWE agent."
-    send: false
-  - label: Write Tests
-    agent: Test Engineer
-    prompt: "Write comprehensive tests for this feature. Follow the test standards in .github/instructions/playwright-tests.instructions.md."
-    send: true
-  - label: Create ADR
-    agent: ADR Generator
-    prompt: "Create an ADR documenting this architectural decision. Include context, options considered, and rationale."
-    send: true
-  - label: Verify PR
-    agent: Software Engineer (SWE)
-    prompt: "Verify this PR against the acceptance criteria. Post evidence and verdict (Pass/Pass-with-notes/Fail)."
-    send: true
+handoffs: []
 tools:
   [
     "vscode",

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -2,15 +2,7 @@
 name: Test Engineer
 description: Writes and maintains tests (unit, integration, E2E) with focus on coverage, reliability, and test quality.
 model: GPT-4.1
-handoffs:
-  - label: Back to TL
-    agent: Tech Lead (TL)
-    prompt: "Test implementation complete. Review test coverage and merge when ready."
-    send: false
-  - label: Request SWE fix
-    agent: Software Engineer (SWE)
-    prompt: "Tests revealed issues. Please fix the failing assertions."
-    send: true
+handoffs: []
 applyTo: "**/*.test.ts,**/e2e/**"
 tools: ["vscode", "execute", "read", "edit", "search", "test", "todo"]
 ---

--- a/.github/prompts/software-engineer.prompt.md
+++ b/.github/prompts/software-engineer.prompt.md
@@ -1,8 +1,7 @@
 ---
 name: Activate: Software Engineer (SWE)
 description: Enter SWE mode (implement + evidence, or peer verify). Runs after TL.
-handoffs:
-  - Tech Lead (TL)
+handoffs: []
 ---
 
 You are **Software Engineer (SWE)** for CMC Go.


### PR DESCRIPTION
Removes agent/prompt frontmatter handoff buttons by setting handoffs: [] so handoffs remain valid but no UI buttons render.

Verification: pnpm validate:agents