### PR TITLE
Chore: Fix unused 'isAuthenticated' variable warnings

### DIFF
--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -40,7 +40,7 @@ export default function ConsoleLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { user, loading, isAuthenticated } = useAuth();
+  const { user, loading, isAuthenticated: _isAuthenticated } = useAuth();
   const [location] = useLocation();
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const logoutMutation = trpc.auth.logout.useMutation({

--- a/client/src/components/PeoplePanel.tsx
+++ b/client/src/components/PeoplePanel.tsx
@@ -33,7 +33,7 @@ interface PeoplePanelProps {
 export function PeoplePanel({ onClose }: PeoplePanelProps) {
   const [selectedPerson, setSelectedPerson] = useState<Person | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const { isAuthenticated } = usePublicAuth();
+  const { isAuthenticated: _isAuthenticated } = usePublicAuth();
   const { user } = useAuth();
   const utils = trpc.useUtils();
 

--- a/client/src/components/PersonIcon.tsx
+++ b/client/src/components/PersonIcon.tsx
@@ -40,7 +40,7 @@ export function PersonIcon({
   onClick,
   onEdit,
 }: PersonIconProps) {
-  const { isAuthenticated } = usePublicAuth();
+  const { isAuthenticated: _isAuthenticated } = usePublicAuth();
   const [isHovered, setIsHovered] = useState(false);
   const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(
     null

--- a/client/src/components/PersonRow.tsx
+++ b/client/src/components/PersonRow.tsx
@@ -42,7 +42,7 @@ export function PersonRow({
   hasNeeds,
   onPersonUpdate,
 }: PersonRowProps) {
-  const { isAuthenticated } = usePublicAuth();
+  const { isAuthenticated: _isAuthenticated } = usePublicAuth();
   const [isHovered, setIsHovered] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
   const utils = trpc.useUtils();

--- a/client/src/pages/Approvals.tsx
+++ b/client/src/pages/Approvals.tsx
@@ -21,7 +21,7 @@ import { useLocation } from "wouter";
 
 export default function Approvals() {
   const [, setLocation] = useLocation();
-  const { user, isAuthenticated } = usePublicAuth();
+  const { user, isAuthenticated: _isAuthenticated } = usePublicAuth();
   const utils = trpc.useUtils();
 
   const { data: pendingApprovals = [], isLoading } =

--- a/client/src/pages/Import.tsx
+++ b/client/src/pages/Import.tsx
@@ -39,7 +39,7 @@ interface ImportResult {
 }
 
 export default function Import() {
-  const { user, isAuthenticated, loading } = useAuth();
+  const { user, isAuthenticated: _isAuthenticated, loading } = useAuth();
   const [file, setFile] = useState<File | null>(null);
   const [csvText, setCsvText] = useState("");
   const [importing, setImporting] = useState(false);

--- a/client/src/pages/Needs.tsx
+++ b/client/src/pages/Needs.tsx
@@ -16,7 +16,7 @@ import { PersonDetailsDialog } from "@/components/PersonDetailsDialog";
 import { Person } from "../../../drizzle/schema";
 
 export default function Needs() {
-  const { user, isAuthenticated, loading } = useAuth();
+  const { user, isAuthenticated: _isAuthenticated, loading } = useAuth();
   const [, setLocation] = useLocation();
   const utils = trpc.useUtils();
   const [resolvingNeedId, setResolvingNeedId] = useState<number | null>(null);


### PR DESCRIPTION
## Summary
Fix 7 lint warnings for unused \isAuthenticated\ variables by aliasing them to \_isAuthenticated\.

## Changes
Alias unused \isAuthenticated\ variables to \_isAuthenticated\ to satisfy the \@typescript-eslint/no-unused-vars\ rule.

**Files modified:**
- \client/src/components/ConsoleLayout.tsx\
- \client/src/components/PeoplePanel.tsx\
- \client/src/components/PersonIcon.tsx\
- \client/src/components/PersonRow.tsx\
- \client/src/pages/Approvals.tsx\
- \client/src/pages/Import.tsx\
- \client/src/pages/Needs.tsx\

## Verification
- [x] \pnpm check\ passes
- [x] \pnpm lint\ shows 0 warnings for isAuthenticated unused
- [x] Client tests pass

Closes #222

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses unused variable lint warnings by aliasing `isAuthenticated` to `_isAuthenticated`.
> 
> - Updates in `ConsoleLayout.tsx`, `PeoplePanel.tsx`, `PersonIcon.tsx`, `PersonRow.tsx`, `Approvals.tsx`, `Import.tsx`, and `Needs.tsx`
> - No logic changes beyond variable renaming for lint compliance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7474cb02e75519f823cd22fbdbc8eb59cde761b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->