### PR TITLE
chore: Fix unused isAuthenticated variable warnings

### DIFF
--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -40,7 +40,7 @@ export default function ConsoleLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { user, loading, isAuthenticated } = useAuth();
+  const { user, loading, isAuthenticated: _isAuthenticated } = useAuth();
   const [location] = useLocation();
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const logoutMutation = trpc.auth.logout.useMutation({

--- a/client/src/components/PeoplePanel.tsx
+++ b/client/src/components/PeoplePanel.tsx
@@ -33,7 +33,7 @@ interface PeoplePanelProps {
 export function PeoplePanel({ onClose }: PeoplePanelProps) {
   const [selectedPerson, setSelectedPerson] = useState<Person | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const { isAuthenticated } = usePublicAuth();
+  const { isAuthenticated: _isAuthenticated } = usePublicAuth();
   const { user } = useAuth();
   const utils = trpc.useUtils();
 

--- a/client/src/components/PersonIcon.tsx
+++ b/client/src/components/PersonIcon.tsx
@@ -40,7 +40,7 @@ export function PersonIcon({
   onClick,
   onEdit,
 }: PersonIconProps) {
-  const { isAuthenticated } = usePublicAuth();
+  const { isAuthenticated: _isAuthenticated } = usePublicAuth();
   const [isHovered, setIsHovered] = useState(false);
   const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(
     null

--- a/client/src/components/PersonRow.tsx
+++ b/client/src/components/PersonRow.tsx
@@ -42,7 +42,7 @@ export function PersonRow({
   hasNeeds,
   onPersonUpdate,
 }: PersonRowProps) {
-  const { isAuthenticated } = usePublicAuth();
+  const { isAuthenticated: _isAuthenticated } = usePublicAuth();
   const [isHovered, setIsHovered] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
   const utils = trpc.useUtils();

--- a/client/src/pages/Approvals.tsx
+++ b/client/src/pages/Approvals.tsx
@@ -21,7 +21,7 @@ import { useLocation } from "wouter";
 
 export default function Approvals() {
   const [, setLocation] = useLocation();
-  const { user, isAuthenticated } = usePublicAuth();
+  const { user, isAuthenticated: _isAuthenticated } = usePublicAuth();
   const utils = trpc.useUtils();
 
   const { data: pendingApprovals = [], isLoading } =

--- a/client/src/pages/Import.tsx
+++ b/client/src/pages/Import.tsx
@@ -39,7 +39,7 @@ interface ImportResult {
 }
 
 export default function Import() {
-  const { user, isAuthenticated, loading } = useAuth();
+  const { user, isAuthenticated: _isAuthenticated, loading } = useAuth();
   const [file, setFile] = useState<File | null>(null);
   const [csvText, setCsvText] = useState("");
   const [importing, setImporting] = useState(false);

--- a/client/src/pages/Needs.tsx
+++ b/client/src/pages/Needs.tsx
@@ -16,7 +16,7 @@ import { PersonDetailsDialog } from "@/components/PersonDetailsDialog";
 import { Person } from "../../../drizzle/schema";
 
 export default function Needs() {
-  const { user, isAuthenticated, loading } = useAuth();
+  const { user, isAuthenticated: _isAuthenticated, loading } = useAuth();
   const [, setLocation] = useLocation();
   const utils = trpc.useUtils();
   const [resolvingNeedId, setResolvingNeedId] = useState<number | null>(null);


### PR DESCRIPTION
## Why

Closes #222

## What changed

- Fixed 7 lint warnings for unused \isAuthenticated\ variables
- Used destructuring alias syntax (\isAuthenticated: _isAuthenticated\) to prefix with underscore indicating intentionally unused

### Files changed:
- \client/src/components/ConsoleLayout.tsx\`n- \client/src/components/PeoplePanel.tsx\`n- \client/src/components/PersonIcon.tsx\`n- \client/src/components/PersonRow.tsx\`n- \client/src/pages/Approvals.tsx\`n- \client/src/pages/Import.tsx\`n- \client/src/pages/Needs.tsx\`n
## How verified

- \pnpm check\ -- PASS (no TypeScript errors)
- \pnpm test\ -- PASS (80 tests passed)
- \pnpm lint | grep isAuthenticated\ -- no warnings

## Risk

low -- Purely lint fix, no functional changes

## End-of-Task Reflection

- **Workflow:** No changes
- **Patterns:** No changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses lint warnings for unused auth flags without changing behavior.
> 
> - Updates destructuring to `isAuthenticated: _isAuthenticated` in `ConsoleLayout.tsx`, `PeoplePanel.tsx`, `PersonIcon.tsx`, `PersonRow.tsx`, `Approvals.tsx`, `Import.tsx`, and `Needs.tsx`
> - No logic, API, or UI changes; purely variable aliasing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb17335cba624131db516b1dcf776545ecdaee79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->