### PR TITLE
chore: Fix unused error variable lint warnings

### DIFF
--- a/client/src/components/DistrictPanel.tsx
+++ b/client/src/components/DistrictPanel.tsx
@@ -461,7 +461,7 @@ export function DistrictPanel({
   });
 
   // Validation state
-  const [householdValidationError, setHouseholdValidationError] = useState<
+  const [_householdValidationError, setHouseholdValidationError] = useState<
     string | null
   >(null);
   const [householdNameError, setHouseholdNameError] = useState<string | null>(
@@ -498,7 +498,7 @@ export function DistrictPanel({
   });
 
   // Fetch households for dropdown
-  const { data: allHouseholds = [], error: householdsError } =
+  const { data: allHouseholds = [], error: _householdsError } =
     trpc.households.list.useQuery(undefined, {
       retry: false,
     });

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -199,7 +199,7 @@ async function startServer() {
       // returned the call will throw and be caught below.
       await checkDbHealth();
       res.status(200).send("OK");
-    } catch (err) {
+    } catch (_err) {
       // If the DB connection fails or health check throws, return a
       // 503 to signal that the service is unhealthy. We do not include
       // error details for security reasons.


### PR DESCRIPTION
## Why

Closes #221

## What changed

- Fixed 3 lint warnings for unused error-related variables
- Used underscore prefix to indicate intentionally unused variables

### Files changed:
- \server/_core/index.ts\ - renamed \err\ to \_err\ in healthz endpoint catch block
- \client/src/components/DistrictPanel.tsx\ - renamed \householdValidationError\ to \_householdValidationError\`n- \client/src/components/DistrictPanel.tsx\ - renamed \householdsError\ to \_householdsError\`n
## How verified

- \pnpm check\ -- PASS (no TypeScript errors)
- \pnpm test\ -- PASS (80 tests passed)
- \pnpm lint | grep err | grep never\ -- no warnings

## Risk

low -- Purely lint fix, no functional changes

## End-of-Task Reflection

- **Workflow:** No changes
- **Patterns:** No changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor lint-only cleanups; no functional changes.
> 
> - Renames unused state `householdValidationError` -> `_householdValidationError` and query error `householdsError` -> `_householdsError` in `client/src/components/DistrictPanel.tsx`
> - Renames catch variable `err` -> `_err` in server `/_core/index.ts` `GET /healthz` handler
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28538c8eb20617bb0777d835ac77f85049aacfee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->