### PR TITLE
feat: Add debounced search filter to People page

### DIFF
--- a/client/src/hooks/useDebounce.ts
+++ b/client/src/hooks/useDebounce.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns a debounced value that only updates after the specified delay
+ * has passed without the value changing.
+ *
+ * @param value The value to debounce
+ * @param delay The debounce delay in milliseconds
+ * @returns The debounced value
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Why

Closes #239

## What changed

- Added `useDebounce` hook (`client/src/hooks/useDebounce.ts`) with configurable delay
- Applied 300ms debounce to search filter in People.tsx
- Improved 'No results' message:
  - Shows search icon and "No results found" with the search query when search returns empty
  - Shows filter icon with "No people match the current filters" when filters return empty
  - Includes 'Clear search' button for quick reset

## How verified

- `pnpm check` — passed (no TypeScript errors)
- `pnpm test` — passed (80 tests, 17 test files)

## Risk

**Low** — Client-side only change, adds UI improvement without modifying data flow or API calls.

## End-of-Task Reflection

- **Workflow:** No changes
- **Patterns:** No changes
- **Friction:** 1
