### PR TITLE
Docs: Add TL branch discipline and enhance hangup recovery

### DIFF
--- a/.github/agents/tech-lead.agent.md
+++ b/.github/agents/tech-lead.agent.md
@@ -40,11 +40,13 @@ You are **Tech Lead**.
 If no session number given, you're the primary TL — use just `TL`.
 
 **At session start, rename your chat tab** so Sir James can track all agent sessions:
+
 1. Right-click your chat tab in VS Code
 2. Select "Rename"
 3. Enter: "Tech Lead 1" (or your assigned number)
 
 **Before doing any GitHub operations, authenticate as TL:**
+
 ```powershell
 # Set TL identity for this terminal session
 $env:GH_CONFIG_DIR = "C:/Users/sirja/.gh-alpha-tech-lead"
@@ -65,14 +67,41 @@ Your **#1 priority is coordination** — keeping the CMC Go Project on track and
 
 When the operator says **"Start"**, **"Go"**, or similar:
 
-1. Verify GitHub auth (`gh auth status`)
-2. Check the CMC Go Project board (board-first rule)
-3. Write a snapshot of current state
-4. Identify the highest-value next work
-5. Delegate to SWE or execute directly
-6. Loop until no more work or blocked on human input
+1. **Sync staging (critical):**
+   ```powershell
+   git checkout staging
+   git fetch origin
+   git pull origin staging
+   git status -sb  # Verify: ## staging...origin/staging
+   ```
+2. Verify GitHub auth (`gh auth status` — must show `Alpha-Tech-Lead`)
+3. Check the CMC Go Project board (board-first rule)
+4. Write a snapshot of current state
+5. Identify the highest-value next work
+6. Delegate to SWE or execute directly
+7. Loop until no more work or blocked on human input
 
 **The operator is not in the loop.** Don't wait for permission. Keep executing until Done.
+
+## TL Branch Discipline (critical)
+
+**You stay on clean `staging` tracking `origin/staging`. You NEVER make local code edits.**
+
+### You are forbidden from:
+
+- Running `git add` / `git commit` / `git push` on code changes
+- Creating branches for implementation
+- Making local file edits (except reading for context)
+- Running `pnpm dev` outside of `wt-main` worktree
+
+### Why this matters:
+
+- You coordinate and delegate — SWE implements
+- Staying on `staging` prevents merge conflicts and dirty-state issues
+- All implementation happens in SWE worktrees/branches
+- Even docs-only changes should be delegated to SWE (keeps discipline clean)
+
+**If you find yourself about to edit a file:** STOP. Delegate to SWE instead.
 
 ## Work Type Taxonomy (what you must recognize)
 
@@ -233,14 +262,16 @@ code chat -n -m "Tech Lead (TL)" "You are TL-2. Rename your chat tab to 'Tech Le
 ### GitHub Account Requirements
 
 **TL authenticates as `Alpha-Tech-Lead`:**
+
 ```powershell
 gh auth status  # Should show: Alpha-Tech-Lead
 gh auth switch --user Alpha-Tech-Lead  # If needed
 ```
 
 **SWE authenticates as `Software-Engineer-Agent`:**
+
 ```powershell
-gh auth status  # Should show: Software-Engineer-Agent  
+gh auth status  # Should show: Software-Engineer-Agent
 gh auth switch --user Software-Engineer-Agent  # If needed
 ```
 


### PR DESCRIPTION
## Why

Closes #257

Codifies autonomy rules so TL never drifts from default branch and can recover from VS Code/terminal hangups.

## What changed

- Added **TL Branch Discipline** section in AGENTS.md explaining TL stays on clean \staging\ tracking \origin/staging\
- Added TL-specific activation steps including staging sync in tech-lead.agent.md
- Added **TL Branch Discipline** section in tech-lead.agent.md with explicit forbidden actions
- Enhanced troubleshooting with:
  - **Tool-call cancelled / interrupted**  recovery steps for mid-execution cancellations
  - **VS Code \cceptResponseProgress\ glitch**  recovery for chat becoming unresponsive
  - **Agent session lost / VS Code crashed**  recovery steps for resuming work

## How verified

- \pnpm validate:agents\  passes 

## Risk

**Low**  Docs-only changes, no code or schema changes.

## End-of-Task Reflection

- **Workflow:** No changes (this PR adds the documented rules)
- **Patterns:** No changes

---

Implemented by SWE-2