### PR TITLE
ci: use PROJECT_AUTOMATION_TOKEN for project sync + labeled trigger

### DIFF
--- a/.github/workflows/auto-project-sync.yml
+++ b/.github/workflows/auto-project-sync.yml
@@ -5,7 +5,7 @@ name: Auto Project Sync
 
 on:
   issues:
-    types: [opened, reopened]
+    types: [opened, reopened, labeled]
   pull_request:
     types: [opened, ready_for_review, closed]
 
@@ -13,6 +13,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  projects: write
 
 env:
   PROJECT_NUMBER: 4
@@ -29,13 +30,18 @@ jobs:
   # Add new Issues to Project 4
   add-issue-to-project:
     name: Add Issue to Project
-    if: github.event_name == 'issues'
+    if: |
+      github.event_name == 'issues' && (
+        github.event.action == 'opened' ||
+        github.event.action == 'reopened' ||
+        (github.event.action == 'labeled' && github.event.label.name == 'agent:copilot-swe')
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Add Issue to Project 4
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const mutation = `
               mutation($projectId: ID!, $contentId: ID!) {
@@ -75,7 +81,7 @@ jobs:
       - name: Add PR to Project 4
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const addMutation = `
               mutation($projectId: ID!, $contentId: ID!) {
@@ -165,7 +171,7 @@ jobs:
       - name: Find and update linked Issues
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
             const body = pr.body || '';


### PR DESCRIPTION
## Why

Enables reliable Project 4 item-add from GitHub Actions without relying on default GITHUB_TOKEN (which can't write to user-owned Projects v2).

## What changed

- Trigger \uto-project-sync.yml\ on \issues:labeled\ (for \gent:copilot-swe\ label)
- Use \PROJECT_AUTOMATION_TOKEN\ secret (from sirjamesoffordii) with fallback to GITHUB_TOKEN
- Added \projects: write\ permission

## How verified

- \gh secret list\ confirms \PROJECT_AUTOMATION_TOKEN\ and \COPILOT_ASSIGN_TOKEN_PRO\ are set

## Risk

low  workflow-only change

---

Supersedes #256 (cloud-agent approach); this PR is cleaner.
