### PR TITLE
ci: add dependabot config (weekly, grouped, low-noise)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot configuration for CMC Go
+# Weekly updates, grouped to reduce PR noise, capped limits
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+
+version: 2
+updates:
+  # npm dependencies (package.json)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
+    groups:
+      # Group all minor and patch updates into one PR
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    # Don't auto-merge majors - review manually
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions versions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+      - "automated"


### PR DESCRIPTION
## Why

Enable automated dependency updates with minimal PR noise.

## What changed

- Added \.github/dependabot.yml\
- npm: weekly on Monday, grouped minor/patch, ignores majors, 5 PR limit
- github-actions: weekly, 3 PR limit

## Risk

low  CI/config only
