### PR TITLE
docs: update model defaults to GPT-5.2, reserve Opus for complex tasks

### DIFF
--- a/.github/agents/software-engineer.agent.md
+++ b/.github/agents/software-engineer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Software Engineer (SWE)
 description: Implements small PRs with evidence, or performs peer verification with a clear verdict.
-model: Claude Opus 4.5
+model: GPT-5.2
 handoffs: []
 tools:
   [
@@ -39,11 +39,13 @@ You are **Software Engineer**.
 If TL didn't give you a number, use just `SWE` (no number).
 
 **At session start, rename your chat tab** so Sir James can track all agent sessions:
+
 1. Right-click your chat tab in VS Code
 2. Select "Rename"
 3. Enter: "Software Engineer 1" (or your assigned number)
 
 **Before doing any GitHub operations, authenticate as SWE:**
+
 ```powershell
 # Set SWE identity for this terminal session
 $env:GH_CONFIG_DIR = "C:/Users/sirja/.gh-software-engineer-agent"
@@ -55,6 +57,7 @@ gh auth status
 **IMPORTANT:** You must set `GH_CONFIG_DIR` in EVERY new terminal session. Without it, you'll be using the human account (sirjamesoffordii).
 
 If not authenticated correctly, run:
+
 ```powershell
 gh auth switch --user Software-Engineer-Agent
 ```
@@ -206,13 +209,13 @@ START (no task given)
 
 ### Signal markers (use these exact strings):
 
-| Marker                                  | Meaning                  | When to use                      |
-| --------------------------------------- | ------------------------ | -------------------------------- |
-| `SWE-<N>-HEARTBEAT: <timestamp>`        | "I'm alive"              | Every 5 minutes or at loop start |
-| `SWE-<N>-CLAIMED: Issue #X`             | "Working on this"        | After claiming an issue          |
-| `SWE-<N>-BLOCKED: Issue #X - <reason>`  | "Need help"              | When stuck                       |
-| `SWE-<N>-COMPLETE: Issue #X, PR #Y`     | "Done, ready for review" | After opening PR                 |
-| `SWE-<N>-IDLE: No work found`           | "Board empty"            | When no Todo items               |
+| Marker                                 | Meaning                  | When to use                      |
+| -------------------------------------- | ------------------------ | -------------------------------- |
+| `SWE-<N>-HEARTBEAT: <timestamp>`       | "I'm alive"              | Every 5 minutes or at loop start |
+| `SWE-<N>-CLAIMED: Issue #X`            | "Working on this"        | After claiming an issue          |
+| `SWE-<N>-BLOCKED: Issue #X - <reason>` | "Need help"              | When stuck                       |
+| `SWE-<N>-COMPLETE: Issue #X, PR #Y`    | "Done, ready for review" | After opening PR                 |
+| `SWE-<N>-IDLE: No work found`          | "Board empty"            | When no Todo items               |
 
 **`<N>` is your session number** (given by TL in spawn prompt, e.g., "You are SWE-1"). If no session number given, use `SWE` without a number.
 
@@ -278,15 +281,16 @@ TL will find it when polling.
 
 **Common hang causes and fixes:**
 
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| Terminal shows "alternate buffer" | Pager opened (less/more) | Run `Agent: Recover terminal` task, then retry with `| cat` suffix |
-| Command hangs forever | Interactive prompt waiting | Cancel, add `--yes` or `--no-input` flag |
-| `npx` command hangs | Package downloading slowly | Wait 2 min max, then cancel and try `pnpm exec` instead |
-| `gh` command hangs | Auth issue or rate limit | Run `gh auth status`, check for errors |
-| MCP server "running on stdio" | Started server manually | This is wrong — MCP servers are managed by VS Code, not terminal |
+| Symptom                           | Cause                      | Fix                                                              |
+| --------------------------------- | -------------------------- | ---------------------------------------------------------------- | ----------- |
+| Terminal shows "alternate buffer" | Pager opened (less/more)   | Run `Agent: Recover terminal` task, then retry with `            | cat` suffix |
+| Command hangs forever             | Interactive prompt waiting | Cancel, add `--yes` or `--no-input` flag                         |
+| `npx` command hangs               | Package downloading slowly | Wait 2 min max, then cancel and try `pnpm exec` instead          |
+| `gh` command hangs                | Auth issue or rate limit   | Run `gh auth status`, check for errors                           |
+| MCP server "running on stdio"     | Started server manually    | This is wrong — MCP servers are managed by VS Code, not terminal |
 
 **If you notice a recurring hang pattern:**
+
 1. Fix it for yourself using the techniques above
 2. Add the pattern to `CMC_GO_PATTERNS.md` under "Terminal & Commands"
 3. Include the fix in your PR reflection
@@ -408,14 +412,16 @@ Stay in one session. No handoffs needed.
 ### Workflow Improvement Check
 
 Ask yourself:
+
 - Did the docs waste my time? (missing info, wrong commands, outdated)
 - Did I have to figure out something that should have been documented?
 - Did the agent instructions miss something important?
 - Did I hit a hang or error that could have been avoided with better docs?
 
 **If yes:** Edit the doc directly **and include the edit in your PR.** Files to consider:
+
 - `AGENTS.md` — workflow rules, process
-- `.github/agents/software-engineer.agent.md` — SWE-specific instructions  
+- `.github/agents/software-engineer.agent.md` — SWE-specific instructions
 - `.github/agents/tech-lead.agent.md` — TL-specific instructions
 - `.github/agents/reference/CMC_GO_PATTERNS.md` — reusable patterns
 
@@ -424,6 +430,7 @@ Ask yourself:
 ### Pattern Learning Check
 
 Ask yourself:
+
 - Did I solve a non-obvious problem others will hit?
 - Did I discover a gotcha or edge case?
 - Did I find a better way to do something?
@@ -528,7 +535,13 @@ You're running in one of two modes:
 
 ## Model & Subagent Usage
 
-**You use Claude Opus 4.5** — optimized for continuous autonomous work with judgment capabilities.
+**You use GPT-5.2 by default** — good balance of capability and cost efficiency.
+
+### When to upgrade to Opus 4.5
+
+- Complexity score 4+ tasks
+- Tasks requiring deep reasoning across many files
+- When GPT-5.2 fails on a task (escalate via model selector)
 
 ### Using Subagents (critical for efficiency)
 
@@ -540,13 +553,13 @@ You're running in one of two modes:
 
 **When to use subagents:**
 
-| Situation                              | Use Subagent?    | Why                                |
-| -------------------------------------- | ---------------- | ---------------------------------- |
-| Need to understand 3+ files            | ✅ Yes (parallel) | Faster than reading sequentially   |
-| Running verification while coding      | ✅ Yes            | Don't block on test runs           |
-| Quick lookup (API signature, etc.)     | ✅ Yes            | Don't lose your train of thought   |
-| Simple sequential task                 | ❌ No             | Overhead not worth it              |
-| Need result before next step           | ❌ No             | Just do it yourself                |
+| Situation                          | Use Subagent?     | Why                              |
+| ---------------------------------- | ----------------- | -------------------------------- |
+| Need to understand 3+ files        | ✅ Yes (parallel) | Faster than reading sequentially |
+| Running verification while coding  | ✅ Yes            | Don't block on test runs         |
+| Quick lookup (API signature, etc.) | ✅ Yes            | Don't lose your train of thought |
+| Simple sequential task             | ❌ No             | Overhead not worth it            |
+| Need result before next step       | ❌ No             | Just do it yourself              |
 
 **Subagent spawning syntax:**
 
@@ -555,7 +568,15 @@ runSubagent("Software Engineer (SWE)", "Research how district filtering works in
 runSubagent("Software Engineer (SWE)", "Run pnpm check and pnpm test, report any failures")
 ```
 
-**Cost note:** Subagents use the same Opus model (3× tokens), so use them for parallelization and non-blocking work, not trivial lookups.
+**Subagent model selection (based on task complexity):**
+
+| Task Complexity | Model    | Cost | Example                    |
+| --------------- | -------- | ---- | -------------------------- |
+| Trivial (0-1)   | GPT 4.1  | 0×   | Lookup, simple read        |
+| Standard (2-4)  | GPT-5.2  | 1×   | Most implementation tasks  |
+| Complex (5-6)   | Opus 4.5 | 3×   | Deep reasoning, many files |
+
+**Cost awareness:** Default to GPT-5.2 (1×). Use Opus (3×) only when needed — we've seen rate limits when spawning multiple Opus subagents.
 
 ### TL uses subagents differently
 

--- a/.github/agents/tech-lead.agent.md
+++ b/.github/agents/tech-lead.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Tech Lead (TL)
 description: "Project coordinator for CMC Go. Scans project status, creates/refines Issues, delegates work. Leads with coordination/triage."
-model: Claude Opus 4.5
+model: GPT-5.2
 handoffs: []
 tools:
   [
@@ -153,7 +153,7 @@ Before delegating, score the task:
 - 0-2: Cloud Agent (GitHub default) — simple async tasks, TL continues working
 - 2-6: SWE (`code chat -m "Software Engineer (SWE)"`) — needs judgment, continuous work
 
-**Both TL and SWE use Opus 4.5** — coordination and continuous implementation both need judgment.
+**TL and SWE use GPT-5.2 by default.** Upgrade to Opus 4.5 (3×) for complexity 4+ tasks only.
 
 ## Execution Model
 
@@ -175,7 +175,7 @@ Use subagents for:
 runSubagent(agentName="Software Engineer (SWE)", prompt="Research how district filtering works")
 ```
 
-**Cost note:** Subagents inherit Opus 4.5 (3× tokens). Use them for parallelization, not trivial lookups.
+**Cost note:** Subagents use GPT-5.2 by default (1× tokens). Use Opus (3×) only for complexity 4+ tasks.
 
 ### Delegated Sessions — When You Want to Continue Working
 
@@ -189,29 +189,24 @@ Use delegated sessions for:
 
 ### Cloud agents (primary async method)
 
-Use `github-pull-request_copilot-coding-agent` tool, `gh agent-task create`, or apply `agent:copilot-swe` label:
+Apply `agent:copilot-swe` label to issues to trigger cloud execution:
 
 - **Non-blocking** — TL continues working immediately
 - Agent creates branch, implements, opens PR
-- TL finds out via `gh agent-task list` or board polling
+- TL finds out via board polling or PR notifications
 - Best for simple issues (score 0-2)
 
-**CLI spawning (recommended for scaling):**
-
-```powershell
-gh agent-task create "Implement Issue #42" --base staging
-gh agent-task list -L 10  # Check status
-```
+**Note:** As `Alpha-Tech-Lead`, you cannot use `gh agent-task create` directly. The `agent:copilot-swe` label triggers `.github/workflows/copilot-auto-handoff.yml` which uses `sirjamesoffordii`'s Plus account token.
 
 ### Scaling strategy
 
 | Need                             | Solution                                   |
 | -------------------------------- | ------------------------------------------ |
 | Research/analysis                | Parallel `runSubagent` (get results back)  |
-| Simple parallel work (0-2)       | `gh agent-task create` (non-blocking)      |
+| Simple parallel work (0-2)       | `agent:copilot-swe` label (non-blocking)   |
 | Complex work, need result now    | Local SWE via runSubagent (blocking is OK) |
-| Bulk tasks (10+ issues)          | Multiple `gh agent-task` (fire and forget) |
-| Need judgment on complex problem | Do it yourself (TL has best model)         |
+| Bulk tasks (10+ issues)          | Multiple `agent:copilot-swe` labels        |
+| Need judgment on complex problem | Upgrade to Opus model for this session     |
 
 ### Terminal-based spawning
 


### PR DESCRIPTION
## Why

Addresses observed rate limits when spawning multiple Opus subagents (observed during this session), and improves cost efficiency.

## What Changed

- **Model defaults:** Changed from Claude Opus 4.5 to GPT-5.2 for both TL and SWE agents
- **Complexity-based selection:** Added clear guidance for model selection:
  - 0-1 (trivial): GPT 4.1 (0 cost)
  - 2-4 (standard): GPT-5.2 (1 cost)  new default
  - 5-6 (complex): Opus 4.5 (3 cost)  reserved for complex tasks
- **TL cloud agent clarification:** TL (\Alpha-Tech-Lead\) cannot use \gh agent-task create\ directly; must use \gent:copilot-swe\ label instead
- **Rate limit documentation:** Added note about observed throttling with parallel Opus subagents
- **SWE subagent guidance:** Added explicit model selection table for SWE spawning subagents

## Files Changed

- \AGENTS.md\  Central workflow model selection sections
- \.github/agents/tech-lead.agent.md\  Frontmatter model + cost notes
- \.github/agents/software-engineer.agent.md\  Frontmatter model + subagent model selection table

## How Verified

- \pnpm check\  passes (no TypeScript changes)
- Manual review of all model references for consistency

## Risk

Low  documentation-only changes. No code behavior changes.

## End-of-Task Reflection

- **Workflow:** \AGENTS.md\  Comprehensive model selection update based on session learnings
- **Patterns:** No changes