### PR TITLE
Server: Add canAccessPerson and peopleScopeWhereClause helpers

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -26,7 +26,11 @@ import {
   InsertInviteNote,
 } from "../drizzle/schema";
 import { ENV } from "./_core/env";
-import type { PeopleScope } from "./_core/authorization";
+import {
+  peopleScopeWhereClause,
+  type PeopleScope,
+  type UserScopeAnchors,
+} from "./_core/authorization";
 
 let _db: ReturnType<typeof drizzle> | null = null;
 let _pool: mysql.Pool | null = null;
@@ -409,6 +413,32 @@ export async function getPersonByPersonId(personId: string) {
     .select()
     .from(people)
     .where(eq(people.personId, personId))
+    .limit(1);
+  return result[0] || null;
+}
+
+export async function personExists(personId: string) {
+  const db = await getDb();
+  if (!db) return false;
+  const result = await db
+    .select({ personId: people.personId })
+    .from(people)
+    .where(eq(people.personId, personId))
+    .limit(1);
+  return Boolean(result[0]);
+}
+
+export async function getPersonByPersonIdInScope(
+  personId: string,
+  user: UserScopeAnchors
+) {
+  const db = await getDb();
+  if (!db) return null;
+
+  const result = await db
+    .select()
+    .from(people)
+    .where(and(eq(people.personId, personId), peopleScopeWhereClause(user)))
     .limit(1);
   return result[0] || null;
 }


### PR DESCRIPTION
Implemented by SWE-1\n\n## Why\n\nCloses #244\n\n## What changed\n\n- Added canAccessPerson and peopleScopeWhereClause helpers for People Visibility scoping\n- Added DB helpers for scoped access (getPersonByPersonIdInScope, personExists) and refactored endpoints to use DB-level filtering\n- Added unit tests for both helpers\n\n## How verified\n\n- pnpm check  pass\n- pnpm test  pass\n\n## Risk\n\nlow  logic is centralized + unit-tested\n\n## End-of-Task Reflection (Required)\n\n### Workflow Improvement Check\n\n- Recommendation: No changes recommended\n- Rationale: Docs/instructions were sufficient\n\n### Pattern Learning Check\n\n- Recommendation: No changes recommended\n- Rationale: No new reusable pattern discovered\n