### PR TITLE
Server: normalize role aliases for people scope

### DIFF
--- a/server/_core/authorization.ts
+++ b/server/_core/authorization.ts
@@ -259,18 +259,23 @@ export type PeopleScope =
   | { level: "ALL" };
 
 function normalizeRole(role: string) {
+  const normalized = role
+    .trim()
+    .toUpperCase()
+    .replace(/[\s-]+/g, "_");
+
   // Campus-level roles - all normalize to appropriate campus scope role
-  if (role === "CAMPUS_CO_DIRECTOR" || role === "CO_DIRECTOR")
-    return "CAMPUS_DIRECTOR";
-  if (role === "CAMPUS_VOLUNTEER" || role === "CAMPUS_INTERN") return "STAFF";
+  if (normalized === "CAMPUS_CO_DIRECTOR") return "CO_DIRECTOR";
+  if (normalized === "CAMPUS_VOLUNTEER" || normalized === "CAMPUS_INTERN")
+    return "STAFF";
 
   // District-level roles
-  if (role === "DISTRICT_STAFF") return "DISTRICT_DIRECTOR";
+  if (normalized === "DISTRICT_STAFF") return "DISTRICT_DIRECTOR";
 
   // Regional-level roles - Regional Staff gets full access
-  if (role === "REGIONAL_STAFF") return "REGIONAL_DIRECTOR";
+  if (normalized === "REGIONAL_STAFF") return "REGION_DIRECTOR";
 
-  return role;
+  return normalized;
 }
 
 const FULL_ACCESS = new Set([

--- a/server/peopleScope.authorization.test.ts
+++ b/server/peopleScope.authorization.test.ts
@@ -206,5 +206,70 @@ describe("people visibility helpers", () => {
       expect(built.sql).toContain("primaryRegion");
       expect(built.params).toEqual(["R-42"]);
     });
+
+    it("normalizes campus-level aliases to CAMPUS scope", () => {
+      const aliases = [
+        "CAMPUS_VOLUNTEER",
+        "Campus Volunteer",
+        "CAMPUS_INTERN",
+        "Campus Intern",
+        "CAMPUS_CO_DIRECTOR",
+        "Campus Co-Director",
+      ];
+
+      for (const role of aliases) {
+        const built = toSql({
+          role,
+          campusId: 7,
+          districtId: "D-7",
+          regionId: "R-7",
+        });
+
+        expect(built.sql).toContain("primaryCampusId");
+        expect(built.params).toEqual([7]);
+      }
+    });
+
+    it("normalizes district-level aliases to DISTRICT_DIRECTOR scope", () => {
+      const aliases = ["DISTRICT_STAFF", "District Staff"];
+
+      for (const role of aliases) {
+        const built = toSql({
+          role,
+          campusId: 7,
+          districtId: "D-7",
+          regionId: "R-7",
+        });
+
+        expect(built.sql).toContain("primaryRegion");
+        expect(built.params).toEqual(["R-7"]);
+      }
+    });
+
+    it("normalizes regional/full-access aliases to ALL scope", () => {
+      const fullAccessRoles = [
+        "REGIONAL_STAFF",
+        "Regional Staff",
+        "REGION_DIRECTOR",
+        "REGIONAL_DIRECTOR",
+        "FIELD_DIRECTOR",
+        "NATIONAL_STAFF",
+        "NATIONAL_DIRECTOR",
+        "CMC_GO_ADMIN",
+        "ADMIN",
+      ];
+
+      for (const role of fullAccessRoles) {
+        const built = toSql({
+          role,
+          campusId: 7,
+          districtId: "D-7",
+          regionId: "R-7",
+        });
+
+        expect(built.sql).toContain("1=1");
+        expect(built.params).toEqual([]);
+      }
+    });
   });
 });


### PR DESCRIPTION
## Why

Closes #246

## What changed

- Normalizes role strings (case/spacing/hyphens) before scope decisions
- Fixes ladder mapping: `CAMPUS_CO_DIRECTOR` now maps to `CO_DIRECTOR` (campus-scoped)
- Adds unit coverage for role alias mappings and full-access roles

## How verified

- `pnpm check`  pass
- `pnpm -s test server/peopleScope.authorization.test.ts`  pass

## Risk

low  scope logic changes are covered by unit tests and only affect role strings outside the strict DB enum.

## End-of-Task Reflection (Required)

### Workflow Improvement Check

- Recommendation: No changes recommended
- Rationale: Standard loop worked.

### Pattern Learning Check

- Recommendation: No changes recommended
- Rationale: Straightforward alias normalization.

Implemented by SWE-4