### PR TITLE
Client: District Panel public-safe mode enhancements

### DIFF
--- a/client/src/components/DistrictDirectorDropZone.tsx
+++ b/client/src/components/DistrictDirectorDropZone.tsx
@@ -271,7 +271,7 @@ export function DistrictDirectorDropZone({
             className="relative transition-all hover:scale-110 active:scale-95"
           >
             {/* Gray spouse icon behind - shown when person has a spouse */}
-            {person.spouse && (
+            {!maskIdentity && person.spouse && (
               <User
                 className="w-10 h-10 text-slate-300 absolute top-0 left-2 pointer-events-none z-0"
                 strokeWidth={1.5}

--- a/client/src/components/DistrictPanel.tsx
+++ b/client/src/components/DistrictPanel.tsx
@@ -47,7 +47,6 @@ import {
   SelectValue,
 } from "./ui/select";
 import { Checkbox } from "./ui/checkbox";
-import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
 import { DroppablePerson } from "./DroppablePerson";
 import { CampusDropZone } from "./CampusDropZone";
 import { CampusNameDropZone } from "./CampusNameDropZone";
@@ -2316,7 +2315,7 @@ export function DistrictPanel({
                 }).map((_, idx) => (
                   <User
                     key={`presence-${idx}`}
-                    className="w-5 h-5 text-slate-300"
+                    className="w-5 h-5 text-zinc-400"
                     strokeWidth={1.5}
                   />
                 ))}

--- a/client/src/components/DistrictStaffDropZone.tsx
+++ b/client/src/components/DistrictStaffDropZone.tsx
@@ -273,7 +273,7 @@ export function DistrictStaffDropZone({
             className="relative transition-all hover:scale-110 active:scale-95"
           >
             {/* Gray spouse icon behind - shown when person has a spouse */}
-            {person.spouse && (
+            {!maskIdentity && person.spouse && (
               <User
                 className="w-10 h-10 text-slate-300 absolute top-0 left-2 pointer-events-none z-0"
                 strokeWidth={1.5}


### PR DESCRIPTION
## Why

Closes #248

## What changed

- Implemented by SWE-3
- Public-safe presence icons use neutral grey (not status colors)
- Hide spouse overlay and other identity-adjacent cues in public-safe mode
- Remove unused tooltip import to keep pnpm check clean

## How verified

- pnpm check  pass
- pnpm test  fails locally (no DATABASE_URL / Docker not running on this machine)

## Risk

low  styling/visibility changes only, gated by public-safe mode

## End-of-Task Reflection (Required)

### Workflow Improvement Check

- Recommendation: No changes recommended
- Rationale: No friction worth documenting.

### Pattern Learning Check

- Recommendation: No changes recommended
- Rationale: No new reusable patterns discovered.