### PR TITLE
[#280] Fix auto-project-sync workflow invalid permission

### DIFF
--- a/.github/workflows/auto-project-sync.yml
+++ b/.github/workflows/auto-project-sync.yml
@@ -13,7 +13,6 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  projects: write
 
 env:
   PROJECT_NUMBER: 4


### PR DESCRIPTION
## Why

Closes #280

## What Changed

- Removed invalid `projects: write` permission from `.github/workflows/auto-project-sync.yml`
- This permission is not valid for GitHub Actions workflows and was causing the workflow to fail
- Project access is provided via the PAT token (`PROJECT_AUTOMATION_TOKEN`), not workflow permissions

## How Verified

```
pnpm check # ✅ TypeScript passes
```

## Risk

Low — Single line removal of invalid permission. No functional code changes.

## End-of-Task Reflection

- **Workflow:** No changes needed
- **Patterns:** No changes needed