### PR TITLE
[#290] Feature: Mobile swipe-to-close panel

### DIFF
--- a/client/src/components/MobileDrawer.tsx
+++ b/client/src/components/MobileDrawer.tsx
@@ -1,19 +1,28 @@
 import { X } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useCallback } from "react";
+import { motion, AnimatePresence, PanInfo, useAnimation } from "framer-motion";
 
 interface MobileDrawerProps {
   isOpen: boolean;
   onClose: () => void;
   children: React.ReactNode;
   title?: string;
+  /** Height of the drawer - can be a CSS value like "50vh" or "45vh" */
+  height?: string;
 }
+
+const SWIPE_CLOSE_THRESHOLD = 100; // pixels to swipe down before closing
+const SWIPE_VELOCITY_THRESHOLD = 500; // velocity in px/s for quick swipes
 
 export function MobileDrawer({
   isOpen,
   onClose,
   children,
   title,
+  height = "50vh",
 }: MobileDrawerProps) {
+  const controls = useAnimation();
+
   // Prevent body scroll when drawer is open
   useEffect(() => {
     if (isOpen) {
@@ -26,32 +35,87 @@ export function MobileDrawer({
     };
   }, [isOpen]);
 
-  if (!isOpen) return null;
+  // Reset animation when drawer opens
+  useEffect(() => {
+    if (isOpen) {
+      controls.start({ y: 0 });
+    }
+  }, [isOpen, controls]);
+
+  const handleDragEnd = useCallback(
+    (_event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+      const shouldClose =
+        info.offset.y > SWIPE_CLOSE_THRESHOLD ||
+        info.velocity.y > SWIPE_VELOCITY_THRESHOLD;
+
+      if (shouldClose) {
+        // Animate out before closing
+        controls.start({ y: "100%" }).then(onClose);
+      } else {
+        // Snap back to open position
+        controls.start({ y: 0 });
+      }
+    },
+    [controls, onClose]
+  );
 
   return (
-    <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 bg-black/50 z-40 md:hidden"
-        onClick={onClose}
-      />
-
-      {/* Drawer */}
-      <div className="fixed inset-x-0 bottom-0 top-16 bg-white z-50 md:hidden overflow-y-auto">
-        {/* Header */}
-        <div className="sticky top-0 bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
-          {title && <h2 className="text-lg font-semibold">{title}</h2>}
-          <button
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 bg-black/50 z-40 md:hidden"
             onClick={onClose}
-            className="ml-auto p-2 hover:bg-gray-100 rounded-full"
-          >
-            <X className="w-5 h-5" />
-          </button>
-        </div>
+          />
 
-        {/* Content */}
-        <div className="p-4">{children}</div>
-      </div>
-    </>
+          {/* Drawer */}
+          <motion.div
+            initial={{ y: "100%" }}
+            animate={controls}
+            exit={{ y: "100%" }}
+            transition={{
+              type: "spring",
+              damping: 30,
+              stiffness: 300,
+            }}
+            drag="y"
+            dragConstraints={{ top: 0, bottom: 0 }}
+            dragElastic={{ top: 0, bottom: 0.5 }}
+            onDragEnd={handleDragEnd}
+            className="fixed inset-x-0 bottom-0 bg-white z-50 md:hidden rounded-t-xl shadow-lg flex flex-col"
+            style={{ height, maxHeight: "85vh" }}
+          >
+            {/* Drag Handle Indicator */}
+            <div className="flex justify-center pt-3 pb-1 cursor-grab active:cursor-grabbing">
+              <div className="w-10 h-1 bg-gray-300 rounded-full" />
+            </div>
+
+            {/* Header */}
+            <div className="bg-white border-b border-gray-200 px-4 py-2 flex items-center justify-between shrink-0">
+              {title && <h2 className="text-lg font-semibold">{title}</h2>}
+              {/* Touch-friendly close button: min 44x44 */}
+              <button
+                onClick={onClose}
+                className="ml-auto p-2.5 hover:bg-gray-100 active:bg-gray-200 rounded-full transition-colors touch-target"
+                style={{ minWidth: 44, minHeight: 44 }}
+                aria-label="Close panel"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            {/* Content - scrollable */}
+            <div className="flex-1 overflow-y-auto overscroll-contain p-4">
+              {children}
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
   );
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -7,6 +7,7 @@ import { DistrictPanel } from "@/components/DistrictPanel";
 import { PeoplePanel } from "@/components/PeoplePanel";
 import { PersonDetailsDialog } from "@/components/PersonDetailsDialog";
 import { ViewModeSelector } from "@/components/ViewModeSelector";
+import { MobileDrawer } from "@/components/MobileDrawer";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -1020,87 +1021,131 @@ export default function Home() {
         className="flex main-content-area md:flex-row flex-col"
         style={{ height: "calc(100vh - 120px)" }}
       >
-        {/* Left District/National Panel */}
-        <div
-          className={[
-            "bg-white border-r border-gray-300 flex-shrink-0 relative",
-            !isResizingDistrict
-              ? "transition-all duration-300 ease-in-out"
-              : "",
-            isMobile ? "left-panel-mobile" : "",
-            isMobile && !(selectedDistrictId || nationalPanelOpen)
-              ? "closed"
-              : "",
-          ]
-            .filter(Boolean)
-            .join(" ")}
-          style={
-            isMobile
-              ? {
-                  width: "100%",
-                  height:
-                    selectedDistrictId || nationalPanelOpen ? "45vh" : "0",
-                  overflow:
-                    selectedDistrictId || nationalPanelOpen ? "auto" : "hidden",
-                }
-              : {
-                  width:
-                    selectedDistrictId || nationalPanelOpen
-                      ? `${districtPanelWidth}%`
-                      : "0%",
-                  height: "100%",
-                  overflow:
-                    selectedDistrictId || nationalPanelOpen ? "auto" : "hidden",
-                }
-          }
-        >
-          {(selectedDistrictId || nationalPanelOpen) && (
-            <>
-              {/* Resize Handle (desktop only) */}
-              {!isMobile && (
+        {/* Left District/National Panel - Desktop */}
+        {!isMobile && (
+          <div
+            className={[
+              "bg-white border-r border-gray-300 flex-shrink-0 relative",
+              !isResizingDistrict
+                ? "transition-all duration-300 ease-in-out"
+                : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            style={{
+              width:
+                selectedDistrictId || nationalPanelOpen
+                  ? `${districtPanelWidth}%`
+                  : "0%",
+              height: "100%",
+              overflow:
+                selectedDistrictId || nationalPanelOpen ? "auto" : "hidden",
+            }}
+          >
+            {(selectedDistrictId || nationalPanelOpen) && (
+              <>
+                {/* Resize Handle (desktop only) */}
                 <div
                   className="absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-gray-400 bg-gray-200 transition-colors z-10"
                   onMouseDown={handleDistrictMouseDown}
                 />
-              )}
-              <AnimatePresence mode="wait">
-                {selectedDistrictId && selectedDistrict && (
-                  <DistrictPanel
-                    key={selectedDistrict.id}
-                    district={selectedDistrict}
-                    campuses={selectedDistrictCampuses}
-                    people={selectedDistrictPeople}
-                    isOutOfScope={!isSelectedDistrictInScope}
-                    onClose={() => {
-                      setSelectedDistrictId(null);
-                      setViewState({
-                        ...viewState,
-                        districtId: null,
-                        regionId: null,
-                        campusId: null,
-                        panelOpen: false,
-                      });
-                    }}
-                    onPersonStatusChange={handlePersonStatusChange}
-                    onPersonAdd={handlePersonAdd}
+                <AnimatePresence mode="wait">
+                  {selectedDistrictId && selectedDistrict && (
+                    <DistrictPanel
+                      key={selectedDistrict.id}
+                      district={selectedDistrict}
+                      campuses={selectedDistrictCampuses}
+                      people={selectedDistrictPeople}
+                      isOutOfScope={!isSelectedDistrictInScope}
+                      onClose={() => {
+                        setSelectedDistrictId(null);
+                        setViewState({
+                          ...viewState,
+                          districtId: null,
+                          regionId: null,
+                          campusId: null,
+                          panelOpen: false,
+                        });
+                      }}
+                      onPersonStatusChange={handlePersonStatusChange}
+                      onPersonAdd={handlePersonAdd}
+                      onPersonClick={handlePersonClick}
+                      onDistrictUpdate={() => {
+                        utils.districts.list.invalidate();
+                        utils.people.list.invalidate();
+                      }}
+                    />
+                  )}
+                </AnimatePresence>
+                {nationalPanelOpen && (
+                  <NationalPanel
+                    onClose={() => setNationalPanelOpen(false)}
                     onPersonClick={handlePersonClick}
-                    onDistrictUpdate={() => {
-                      utils.districts.list.invalidate();
-                      utils.people.list.invalidate();
-                    }}
+                    onPersonStatusChange={handlePersonStatusChange}
                   />
                 )}
-              </AnimatePresence>
-              {nationalPanelOpen && (
-                <NationalPanel
-                  onClose={() => setNationalPanelOpen(false)}
-                  onPersonClick={handlePersonClick}
-                  onPersonStatusChange={handlePersonStatusChange}
-                />
-              )}
-            </>
-          )}
-        </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Left District/National Panel - Mobile (swipe-to-close drawer) */}
+        {isMobile && (
+          <MobileDrawer
+            isOpen={!!(selectedDistrictId || nationalPanelOpen)}
+            onClose={() => {
+              setSelectedDistrictId(null);
+              setNationalPanelOpen(false);
+              setViewState({
+                ...viewState,
+                districtId: null,
+                regionId: null,
+                campusId: null,
+                panelOpen: false,
+              });
+            }}
+            title={
+              nationalPanelOpen
+                ? "National Team"
+                : (selectedDistrict?.name ?? "District")
+            }
+            height="70vh"
+          >
+            {selectedDistrictId && selectedDistrict && (
+              <DistrictPanel
+                key={selectedDistrict.id}
+                district={selectedDistrict}
+                campuses={selectedDistrictCampuses}
+                people={selectedDistrictPeople}
+                isOutOfScope={!isSelectedDistrictInScope}
+                onClose={() => {
+                  setSelectedDistrictId(null);
+                  setViewState({
+                    ...viewState,
+                    districtId: null,
+                    regionId: null,
+                    campusId: null,
+                    panelOpen: false,
+                  });
+                }}
+                onPersonStatusChange={handlePersonStatusChange}
+                onPersonAdd={handlePersonAdd}
+                onPersonClick={handlePersonClick}
+                onDistrictUpdate={() => {
+                  utils.districts.list.invalidate();
+                  utils.people.list.invalidate();
+                }}
+              />
+            )}
+            {nationalPanelOpen && (
+              <NationalPanel
+                onClose={() => setNationalPanelOpen(false)}
+                onPersonClick={handlePersonClick}
+                onPersonStatusChange={handlePersonStatusChange}
+              />
+            )}
+          </MobileDrawer>
+        )}
 
         {/* Center Map Area */}
         <div
@@ -1179,43 +1224,47 @@ export default function Home() {
           </div>
         </div>
 
-        {/* Right People Panel */}
-        <div
-          className={[
-            "bg-white border-l border-gray-100 flex-shrink-0 relative flex flex-col",
-            !isResizingPeople ? "transition-all duration-300 ease-in-out" : "",
-            isMobile ? "right-panel-mobile" : "",
-            isMobile && !peoplePanelOpen ? "closed" : "",
-          ]
-            .filter(Boolean)
-            .join(" ")}
-          style={
-            isMobile
-              ? {
-                  width: "100%",
-                  height: peoplePanelOpen ? "50vh" : "0",
-                  overflow: "hidden",
-                }
-              : {
-                  width: peoplePanelOpen ? `${peoplePanelWidth}%` : "0%",
-                  height: "100%",
-                  overflow: "hidden",
-                }
-          }
-        >
-          {peoplePanelOpen && (
-            <>
-              {/* Resize Handle */}
-              {!isMobile && (
+        {/* Right People Panel - Desktop */}
+        {!isMobile && (
+          <div
+            className={[
+              "bg-white border-l border-gray-100 flex-shrink-0 relative flex flex-col",
+              !isResizingPeople
+                ? "transition-all duration-300 ease-in-out"
+                : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            style={{
+              width: peoplePanelOpen ? `${peoplePanelWidth}%` : "0%",
+              height: "100%",
+              overflow: "hidden",
+            }}
+          >
+            {peoplePanelOpen && (
+              <>
+                {/* Resize Handle */}
                 <div
                   className="absolute top-0 left-0 w-1 h-full cursor-col-resize hover:bg-gray-400 bg-gray-200 transition-colors z-10"
                   onMouseDown={handlePeopleMouseDown}
                 />
-              )}
-              <PeoplePanel onClose={() => setPeoplePanelOpen(false)} />
-            </>
-          )}
-        </div>
+                <PeoplePanel onClose={() => setPeoplePanelOpen(false)} />
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Right People Panel - Mobile (swipe-to-close drawer) */}
+        {isMobile && (
+          <MobileDrawer
+            isOpen={peoplePanelOpen}
+            onClose={() => setPeoplePanelOpen(false)}
+            title="People"
+            height="70vh"
+          >
+            <PeoplePanel onClose={() => setPeoplePanelOpen(false)} />
+          </MobileDrawer>
+        )}
       </div>
 
       {/* People Tab Button - Fixed to right side, slides out from edge on hover */}


### PR DESCRIPTION
## Why

Closes #290

Improves mobile UX by adding swipe-to-close functionality to panels, making the app more intuitive and touch-friendly on mobile devices.

## What Changed

- **Enhanced MobileDrawer component** with framer-motion for smooth swipe gestures
  - Slide-up animation with spring physics (damping: 30, stiffness: 300)
  - Swipe-down-to-close with velocity detection (100px threshold or 500px/s velocity)
  - Drag handle indicator for visual affordance
  - Touch-friendly close button (44x44 min size per Apple HIG)
  
- **Integrated MobileDrawer into Home.tsx**
  - District/National panel uses MobileDrawer on mobile
  - People panel uses MobileDrawer on mobile
  - Desktop panels unchanged (side-by-side with resize handles)

## How Verified

\\\ash
pnpm check # ✅
pnpm test  # ✅ (351 tests pass)
\\\

Manual testing recommended on mobile viewport (Chrome DevTools device mode).

## Risk

Low — Changes are scoped to mobile view only. Desktop behavior is completely unchanged. Uses existing framer-motion dependency already in the project.