### PR TITLE
[#298] Fix header image not persisting after page refresh

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -242,10 +242,8 @@ export default function Home() {
     retry: false, // Don't retry on auth errors
   });
 
-  // Fetch saved header image, background color, height, and logo
-  const { data: savedHeaderImage } = trpc.settings.get.useQuery({
-    key: "headerImageUrl",
-  });
+  // Fetch saved header image URL (fresh presigned URL generated on each request)
+  const { data: savedHeaderImage } = trpc.settings.getHeaderImageUrl.useQuery();
   const { data: savedBgColor } = trpc.settings.get.useQuery({
     key: "headerBgColor",
   });
@@ -266,7 +264,7 @@ export default function Home() {
       if (data.backgroundColor) {
         setHeaderBgColor(data.backgroundColor);
       }
-      utils.settings.get.invalidate({ key: "headerImageUrl" });
+      utils.settings.getHeaderImageUrl.invalidate();
       utils.settings.get.invalidate({ key: "headerBgColor" });
     },
   });
@@ -365,15 +363,15 @@ export default function Home() {
     updateSetting.mutate({ key: "headerBgColor", value: color });
   };
 
-  // Set header image from database on load
+  // Set header image from database on load (fresh presigned URL)
   useEffect(() => {
     console.log(
       "[Header] savedHeaderImage raw:",
       JSON.stringify(savedHeaderImage)
     );
-    if (savedHeaderImage && savedHeaderImage.value) {
-      console.log("[Header] Setting header image URL:", savedHeaderImage.value);
-      setHeaderImageUrl(savedHeaderImage.value);
+    if (savedHeaderImage && savedHeaderImage.url) {
+      console.log("[Header] Setting header image URL:", savedHeaderImage.url);
+      setHeaderImageUrl(savedHeaderImage.url);
     }
   }, [savedHeaderImage]);
 

--- a/design/mobile/Home.mobile.tsx
+++ b/design/mobile/Home.mobile.tsx
@@ -72,10 +72,8 @@ export default function Home() {
   const { data: metrics } = trpc.metrics.get.useQuery();
   const { data: allNeeds = [] } = trpc.needs.listActive.useQuery();
 
-  // Fetch saved header image, background color, height, and logo
-  const { data: savedHeaderImage } = trpc.settings.get.useQuery({
-    key: "headerImageUrl",
-  });
+  // Fetch saved header image URL (fresh presigned URL generated on each request)
+  const { data: savedHeaderImage } = trpc.settings.getHeaderImageUrl.useQuery();
   const { data: savedBgColor } = trpc.settings.get.useQuery({
     key: "headerBgColor",
   });
@@ -96,7 +94,7 @@ export default function Home() {
       if (data.backgroundColor) {
         setHeaderBgColor(data.backgroundColor);
       }
-      utils.settings.get.invalidate({ key: "headerImageUrl" });
+      utils.settings.getHeaderImageUrl.invalidate();
       utils.settings.get.invalidate({ key: "headerBgColor" });
     },
   });
@@ -195,15 +193,15 @@ export default function Home() {
     updateSetting.mutate({ key: "headerBgColor", value: color });
   };
 
-  // Set header image from database on load
+  // Set header image from database on load (fresh presigned URL)
   useEffect(() => {
     console.log(
       "[Header] savedHeaderImage raw:",
       JSON.stringify(savedHeaderImage)
     );
-    if (savedHeaderImage && savedHeaderImage.value) {
-      console.log("[Header] Setting header image URL:", savedHeaderImage.value);
-      setHeaderImageUrl(savedHeaderImage.value);
+    if (savedHeaderImage && savedHeaderImage.url) {
+      console.log("[Header] Setting header image URL:", savedHeaderImage.url);
+      setHeaderImageUrl(savedHeaderImage.url);
     }
   }, [savedHeaderImage]);
 


### PR DESCRIPTION
## Why

Closes #298

## What Changed

**Root Cause:** The presigned S3 URL returned by \storagePut\ was being stored directly in the database. Presigned URLs expire (typically 1 hour to 7 days), so after expiration the image would fail to load on page refresh.

**Fix:**
- Store the file **key** (path) instead of the presigned URL in database (\headerImageKey\ instead of \headerImageUrl\)
- Add new \settings.getHeaderImageUrl\ endpoint that generates a fresh presigned URL on each request using \storageGet\
- Update client \Home.tsx\ to use the new endpoint
- Update mobile \Home.mobile.tsx\ with the same fix

**Files Changed:**
- \server/routers.ts\ - Store key, add new endpoint
- \client/src/pages/Home.tsx\ - Use new endpoint
- \design/mobile/Home.mobile.tsx\ - Use new endpoint

## How Verified

\\\
pnpm check # ✅
pnpm test # ✅ (351 tests pass)
\\\

## Risk

Low — The fix is straightforward: store a persistent key instead of an expiring URL, and generate fresh URLs on retrieval. This pattern is the standard approach for handling presigned S3 URLs.