### PR TITLE
[#308] Add archived flag to campuses schema

### DIFF
--- a/drizzle/0008_add_campus_archived_flag.sql
+++ b/drizzle/0008_add_campus_archived_flag.sql
@@ -1,0 +1,11 @@
+-- Migration: Add archived flag and archivedAt timestamp to campuses table
+-- Issue: #308 - Server: Add archived flag to campuses schema
+
+-- Add archived column with default false
+ALTER TABLE `campuses` ADD COLUMN `archived` BOOLEAN NOT NULL DEFAULT false;
+
+-- Add archivedAt timestamp for audit trail
+ALTER TABLE `campuses` ADD COLUMN `archivedAt` TIMESTAMP NULL;
+
+-- Add index for filtering archived campuses
+CREATE INDEX `campuses_archived_idx` ON `campuses` (`archived`);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -103,6 +103,8 @@ export type InsertDistrict = typeof districts.$inferInsert;
 
 /**
  * Campuses table - represents campuses within districts
+ * archived: soft-delete flag (default false), archived campuses are excluded from default queries
+ * archivedAt: timestamp for audit trail when campus was archived
  */
 export const campuses = mysqlTable(
   "campuses",
@@ -111,10 +113,14 @@ export const campuses = mysqlTable(
     name: varchar("name", { length: 255 }).notNull(),
     districtId: varchar("districtId", { length: 64 }).notNull(),
     displayOrder: int("displayOrder").notNull().default(0), // Visual ordering within district
+    archived: boolean("archived").notNull().default(false), // Soft-delete flag
+    archivedAt: timestamp("archivedAt"), // Audit trail timestamp
   },
   table => ({
     // PR 6: Add index for districtId lookups
     districtIdIdx: index("campuses_districtId_idx").on(table.districtId),
+    // Index for filtering archived campuses
+    archivedIdx: index("campuses_archived_idx").on(table.archived),
   })
 );
 


### PR DESCRIPTION
## Summary
Implements soft-delete for campuses via an archived flag instead of hard DELETE.

## Changes
- **Schema**: Added `archived` (boolean, default false) and `archivedAt` (timestamp) columns to campuses table
- **Migration**: Created `0008_add_campus_archived_flag.sql` with column additions and index
- **Archive mutation**: Now sets `archived=true` instead of deleting the row
- **Query filtering**: `getAllCampuses()` and `getCampusesByDistrictId()` exclude archived campuses by default
- **New functions**: Added `archiveCampus()` and `unarchiveCampus()` to db.ts

## Testing
- `pnpm check` passes
- Tests require migration to be applied to staging DB (schema change)

## Migration Required
After merge, run the migration on staging to add the new columns.

Closes #308