### PR TITLE
[#311] Fix ESLint unused import/variable warnings

### DIFF
--- a/client/src/components/CampusDropZone.tsx
+++ b/client/src/components/CampusDropZone.tsx
@@ -19,7 +19,7 @@ export function CampusDropZone({
   children,
   canInteract = true,
 }: CampusDropZoneProps) {
-  const [{ isOver, canDrop }, drop] = useDrop(
+  const [{ isOver: _isOver, canDrop: _canDrop }, drop] = useDrop(
     () => ({
       accept: "person",
       drop: (

--- a/client/src/components/CampusRow.tsx
+++ b/client/src/components/CampusRow.tsx
@@ -4,15 +4,6 @@ import { PersonIcon } from "./PersonIcon";
 import { EditableText } from "./EditableText";
 import { trpc } from "../lib/trpc";
 import { MoreVertical, User, Plus, Check, Edit2, Trash2 } from "lucide-react";
-import { Button } from "./ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "./ui/dropdown-menu";
 
 interface CampusRowProps {
   campus: Campus;

--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -2,7 +2,6 @@ import { useAuth } from "@/_core/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
-import { getLoginUrl } from "@/const";
 import {
   Activity,
   Database,
@@ -40,7 +39,7 @@ export default function ConsoleLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { user, loading, isAuthenticated } = useAuth();
+  const { user, loading, isAuthenticated: _isAuthenticated } = useAuth();
   const [location] = useLocation();
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const logoutMutation = trpc.auth.logout.useMutation({

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -19,7 +19,6 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { getLoginUrl } from "@/const";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import {
   LayoutDashboard,
@@ -31,7 +30,6 @@ import {
 import { CSSProperties, useEffect, useRef, useState } from "react";
 import { useLocation } from "wouter";
 import { DashboardLayoutSkeleton } from "./DashboardLayoutSkeleton";
-import { Button } from "./ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 const menuItems = [
@@ -54,7 +52,7 @@ export default function DashboardLayout({
     const saved = localStorage.getItem(SIDEBAR_WIDTH_KEY);
     return saved ? parseInt(saved, 10) : DEFAULT_WIDTH;
   });
-  const { loading, user } = useAuth();
+  const { loading, user: _user } = useAuth();
 
   useEffect(() => {
     localStorage.setItem(SIDEBAR_WIDTH_KEY, sidebarWidth.toString());

--- a/client/src/components/DistrictDirectorDropZone.tsx
+++ b/client/src/components/DistrictDirectorDropZone.tsx
@@ -39,15 +39,6 @@ interface DistrictDirectorDropZoneProps {
   maskIdentity?: boolean;
 }
 
-interface Need {
-  id: number;
-  personId: string;
-  type: string;
-  description: string;
-  amount?: number | null;
-  isActive: boolean;
-}
-
 export function DistrictDirectorDropZone({
   person,
   onDrop,
@@ -59,7 +50,7 @@ export function DistrictDirectorDropZone({
   onQuickAddNameChange,
   onQuickAddSubmit,
   onQuickAddCancel,
-  onQuickAddClick,
+  onQuickAddClick: _onQuickAddClick,
   quickAddInputRef,
   districtId = null,
   canInteract = true,
@@ -79,7 +70,7 @@ export function DistrictDirectorDropZone({
   );
   const personNeed = person && personNeeds.length > 0 ? personNeeds[0] : null;
 
-  const [{ isOver, canDrop }, drop] = useDrop(
+  const [{ isOver: _isOver, canDrop: _canDrop }, drop] = useDrop(
     () => ({
       accept: "person",
       drop: (item: { personId: string; campusId: string | number }) => {


### PR DESCRIPTION
## Summary
Fixes ESLint warnings for unused imports and variables in 5 client components.

Closes #311

## Changes
- CampusDropZone.tsx: Prefix unused isOver/canDrop destructured variables with _
- CampusRow.tsx: Remove unused Button and entire DropdownMenu import block
- ConsoleLayout.tsx: Remove unused getLoginUrl import, prefix unused isAuthenticated with _
- DashboardLayout.tsx: Remove unused getLoginUrl and Button imports, prefix unused user with _
- DistrictDirectorDropZone.tsx: Remove unused Need interface, prefix unused vars with _

## Evidence
- pnpm check: PASS
- pnpm lint (target files): 0 unused variable warnings

Note: Some unrelated tests fail due to pre-existing schema sync issues (archived column missing) - not introduced by this PR.