### PR TITLE
[#306] Document migration sync step for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ CMC Go is a map-first coordination app for CMC conference attendance management.
 
 - Install: `pnpm install`
 - Local DB + seed (dev only): `pnpm db:setup`
+- After pulling new migrations: `pnpm db:push:yes`
 - Dev server: `pnpm dev`
 - Tests: `pnpm test`
 - E2E smoke: `pnpm e2e`

--- a/docs/project/REPO_README.md
+++ b/docs/project/REPO_README.md
@@ -240,8 +240,11 @@ VITE_FRONTEND_FORGE_API_KEY=
 # Install dependencies
 pnpm install
 
-# Push database schema (if needed)
-pnpm db:push
+# Push database schema (runs pending migrations)
+pnpm db:push:yes
+
+# Re-run after pulling new migrations
+pnpm db:push:yes
 
 # Seed database (if starting fresh)
 node scripts/seed-db.mjs


### PR DESCRIPTION
Closes #306\n\n## Summary\n- document running \pnpm db:push:yes\ after pulling migrations in quickstart\n- update local dev setup to use \pnpm db:push:yes\ for schema sync\n\n## Testing\n- not run (docs-only change)\n\n## Notes\n- CI already runs \pnpm db:push:yes\ in test workflow\n- production DB verification requires credentials; not performed here