### PR TITLE
[#431] Remove @ts-nocheck from DraggableCampusRow.tsx

### DIFF
--- a/client/src/components/DraggableCampusRow.tsx
+++ b/client/src/components/DraggableCampusRow.tsx
@@ -1,6 +1,5 @@
-// @ts-nocheck
 import { useDrag } from "react-dnd";
-import { ReactNode } from "react";
+import { ReactNode, useCallback } from "react";
 import { getEmptyImage } from "react-dnd-html5-backend";
 import { useEffect } from "react";
 
@@ -34,11 +33,20 @@ export function DraggableCampusRow({
     preview(getEmptyImage(), { captureDraggingState: true });
   }, [preview]);
 
+  const setDragRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node && canInteract) {
+        drag(node);
+      }
+    },
+    [drag, canInteract]
+  );
+
   const opacity = isDragging || dragState ? 0.5 : 1;
 
   return (
     <div
-      ref={canInteract ? drag : undefined}
+      ref={setDragRef}
       style={{ opacity }}
       className={`relative z-10 ${canInteract ? "cursor-grab active:cursor-grabbing" : "cursor-default"}`}
     >


### PR DESCRIPTION
## Summary
Remove ts-nocheck directive and add proper TypeScript types to DraggableCampusRow.tsx.

## Changes
- Remove ts-nocheck directive (now properly typed)
- Use callback ref pattern for drag ref
- Import useCallback for ref handling

## Evidence
pnpm check passes, npx eslint returns no warnings.

Closes #431