### PR TITLE
[#446] Remove @ts-nocheck from PersonTooltip.tsx

### DIFF
--- a/client/src/components/PersonTooltip.tsx
+++ b/client/src/components/PersonTooltip.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Person } from "../../../drizzle/schema";
 import { Check } from "lucide-react";
 import { Checkbox } from "./ui/checkbox";
@@ -23,9 +22,6 @@ export function PersonTooltip({ person, need, position }: PersonTooltipProps) {
     {
       enabled: !!person.householdId && person.householdId !== null,
       retry: false,
-      onError: error => {
-        console.error("Error fetching household:", error);
-      },
     }
   );
   // Fetch all people to get household members
@@ -60,6 +56,7 @@ export function PersonTooltip({ person, need, position }: PersonTooltipProps) {
                   {household.label ||
                     (() => {
                       const members = allPeople.filter(
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         (p: any) => p.householdId === household.id
                       );
                       return members.length > 0


### PR DESCRIPTION
## Summary
Removes @ts-nocheck from PersonTooltip.tsx

## Changes
- Remove @ts-nocheck directive
- Remove deprecated onError option from tRPC query (not supported in tRPC v11)
- Add eslint-disable for intentional any type in filter callback

## Verification
pnpm check passes
pnpm exec eslint client/src/components/PersonTooltip.tsx has no warnings

## CI Note
Test failures are pre-existing (staging DB missing migration 0008 - archived column).

Closes #446