### PR TITLE
[#454] Add console router and remove @ts-nocheck from ConsoleAPI

### DIFF
--- a/.github/agents/workspace-ready.signal
+++ b/.github/agents/workspace-ready.signal
@@ -1,5 +1,5 @@
 ﻿{
-    "workspace":  "C:\\Dev\\CMC Go",
-    "timestamp":  "2026-02-04T04:46:50Z",
-    "pid":  50288
+    "workspace":  "C:\\Dev\\CMC-Go-Worktrees\\wt-se",
+    "timestamp":  "2026-02-04T08:05:02Z",
+    "pid":  64736
 }

--- a/client/src/pages/ConsoleAPI.tsx
+++ b/client/src/pages/ConsoleAPI.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// @ts-nocheck
 import ConsoleLayout from "@/components/ConsoleLayout";
 import { Button } from "@/components/ui/button";
 import {
@@ -188,7 +186,10 @@ export default function ConsoleAPI() {
             <div className="grid gap-4 md:grid-cols-4">
               <div className="space-y-2">
                 <Label htmlFor="method">Method</Label>
-                <Select value={method} onValueChange={v => setMethod(v as any)}>
+                <Select
+                  value={method}
+                  onValueChange={v => setMethod(v as typeof method)}
+                >
                   <SelectTrigger id="method">
                     <SelectValue />
                   </SelectTrigger>

--- a/server/_core/consoleRouter.ts
+++ b/server/_core/consoleRouter.ts
@@ -1,0 +1,227 @@
+import { adminProcedure, router } from "./trpc";
+
+/**
+ * API endpoint metadata for the console API explorer
+ */
+interface ApiEndpoint {
+  id: string;
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  path: string;
+  description: string;
+  isPublic: boolean;
+}
+
+/**
+ * Console router for admin API exploration tools
+ * Used by the ConsoleAPI page for listing and testing endpoints
+ */
+export const consoleRouter = router({
+  apiEndpoints: router({
+    /**
+     * List all available API endpoints in the system
+     * This is metadata about the tRPC API surface for admin exploration
+     */
+    list: adminProcedure.query((): ApiEndpoint[] => {
+      // Return metadata about the app's API endpoints
+      // These are the main tRPC endpoints available in the system
+      return [
+        // Auth endpoints
+        {
+          id: "auth-me",
+          method: "GET",
+          path: "/api/trpc/auth.me",
+          description: "Get current authenticated user",
+          isPublic: true,
+        },
+        {
+          id: "auth-login",
+          method: "POST",
+          path: "/api/trpc/auth.login",
+          description: "Authenticate with email and password",
+          isPublic: true,
+        },
+        {
+          id: "auth-logout",
+          method: "POST",
+          path: "/api/trpc/auth.logout",
+          description: "Clear authentication session",
+          isPublic: false,
+        },
+
+        // People endpoints
+        {
+          id: "people-list",
+          method: "GET",
+          path: "/api/trpc/people.list",
+          description: "List all people (with authorization scope)",
+          isPublic: false,
+        },
+        {
+          id: "people-get",
+          method: "GET",
+          path: "/api/trpc/people.get",
+          description: "Get a person by ID",
+          isPublic: false,
+        },
+        {
+          id: "people-create",
+          method: "POST",
+          path: "/api/trpc/people.create",
+          description: "Create a new person",
+          isPublic: false,
+        },
+        {
+          id: "people-update",
+          method: "POST",
+          path: "/api/trpc/people.update",
+          description: "Update a person's details",
+          isPublic: false,
+        },
+        {
+          id: "people-delete",
+          method: "POST",
+          path: "/api/trpc/people.delete",
+          description: "Delete a person",
+          isPublic: false,
+        },
+
+        // Districts endpoints
+        {
+          id: "districts-list",
+          method: "GET",
+          path: "/api/trpc/districts.list",
+          description: "List all districts",
+          isPublic: true,
+        },
+        {
+          id: "districts-get",
+          method: "GET",
+          path: "/api/trpc/districts.get",
+          description: "Get a district by ID",
+          isPublic: true,
+        },
+
+        // Campuses endpoints
+        {
+          id: "campuses-list",
+          method: "GET",
+          path: "/api/trpc/campuses.list",
+          description: "List all campuses",
+          isPublic: false,
+        },
+        {
+          id: "campuses-create",
+          method: "POST",
+          path: "/api/trpc/campuses.create",
+          description: "Create a new campus",
+          isPublic: false,
+        },
+
+        // Users/Admin endpoints
+        {
+          id: "admin-users-list",
+          method: "GET",
+          path: "/api/trpc/admin.users.list",
+          description: "List all users (admin only)",
+          isPublic: false,
+        },
+        {
+          id: "admin-users-create",
+          method: "POST",
+          path: "/api/trpc/admin.users.create",
+          description: "Create a new user (admin only)",
+          isPublic: false,
+        },
+
+        // Settings endpoints
+        {
+          id: "settings-get",
+          method: "GET",
+          path: "/api/trpc/settings.get",
+          description: "Get application settings",
+          isPublic: false,
+        },
+        {
+          id: "settings-update",
+          method: "POST",
+          path: "/api/trpc/settings.update",
+          description: "Update application settings",
+          isPublic: false,
+        },
+
+        // Needs endpoints
+        {
+          id: "needs-list",
+          method: "GET",
+          path: "/api/trpc/needs.list",
+          description: "List all needs",
+          isPublic: false,
+        },
+        {
+          id: "needs-create",
+          method: "POST",
+          path: "/api/trpc/needs.create",
+          description: "Create a new need",
+          isPublic: false,
+        },
+
+        // Notes endpoints
+        {
+          id: "notes-list",
+          method: "GET",
+          path: "/api/trpc/notes.list",
+          description: "List all notes for a person",
+          isPublic: false,
+        },
+        {
+          id: "notes-create",
+          method: "POST",
+          path: "/api/trpc/notes.create",
+          description: "Create a new note",
+          isPublic: false,
+        },
+
+        // System endpoints
+        {
+          id: "system-health",
+          method: "GET",
+          path: "/api/trpc/system.health",
+          description: "System health check",
+          isPublic: true,
+        },
+
+        // Import endpoints
+        {
+          id: "import-preview",
+          method: "POST",
+          path: "/api/trpc/import.preview",
+          description: "Preview CSV import",
+          isPublic: false,
+        },
+        {
+          id: "import-execute",
+          method: "POST",
+          path: "/api/trpc/import.execute",
+          description: "Execute CSV import",
+          isPublic: false,
+        },
+
+        // Households endpoints
+        {
+          id: "households-list",
+          method: "GET",
+          path: "/api/trpc/households.list",
+          description: "List all households",
+          isPublic: false,
+        },
+        {
+          id: "households-create",
+          method: "POST",
+          path: "/api/trpc/households.create",
+          description: "Create a new household",
+          isPublic: false,
+        },
+      ];
+    }),
+  }),
+});

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -1,3 +1,4 @@
+import { consoleRouter } from "./_core/consoleRouter";
 import { systemRouter } from "./_core/systemRouter";
 import {
   publicProcedure,
@@ -104,6 +105,7 @@ const ROLES_REQUIRING_OVERSEE_REGION = [
 ] as const;
 
 export const appRouter = router({
+  console: consoleRouter,
   system: systemRouter,
   auth: router({
     // PR 2: Get current user with district/region/campus names


### PR DESCRIPTION
Closes #454

## Summary
Implement the missing \console\ router backend and remove \@ts-nocheck\ from ConsoleAPI.tsx.

## Changes

### New Files
- **server/_core/consoleRouter.ts**: New router with \console.apiEndpoints.list\ endpoint
  - Returns metadata about available tRPC API endpoints
  - Admin-protected endpoint (only accessible to authenticated admins)
  - Lists all major API endpoints with method, path, description, and public/protected status

### Modified Files
- **server/routers.ts**: Import and register the consoleRouter in appRouter
- **client/src/pages/ConsoleAPI.tsx**:
  - Removed \@ts-nocheck\ directive (was hiding the missing backend)
  - Fixed ESLint warning: \ as any\ → \ as typeof method\ for proper typing

## Technical Details
The ConsoleAPI page is an admin tool for API exploration. It needs:
- \	rpc.console.apiEndpoints.list\ - returns list of endpoints with id, method, path, description, isPublic

The new consoleRouter provides this metadata about the tRPC API surface.

## Verification
- ✅ \pnpm check\ passes
- ✅ \pnpm test\ passes (451 tests)
- ✅ \
px eslint client/src/pages/ConsoleAPI.tsx\ - no warnings
- ✅ \
px eslint server/_core/consoleRouter.ts\ - no warnings