### PR TITLE
[#443] Add activityLogs router and remove @ts-nocheck from ConsoleLogs

### DIFF
--- a/client/src/pages/ConsoleLogs.tsx
+++ b/client/src/pages/ConsoleLogs.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// @ts-nocheck
 import ConsoleLayout from "@/components/ConsoleLayout";
 import {
   Card,

--- a/server/_core/consoleRouter.ts
+++ b/server/_core/consoleRouter.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { adminProcedure, router } from "./trpc";
 
 /**
@@ -9,6 +10,19 @@ interface ApiEndpoint {
   path: string;
   description: string;
   isPublic: boolean;
+}
+
+/**
+ * Activity log entry for admin console
+ */
+interface ActivityLog {
+  id: number;
+  action: string;
+  resource: string | null;
+  details: string | null;
+  createdAt: Date;
+  userId: number | null;
+  ipAddress: string | null;
 }
 
 /**
@@ -223,5 +237,41 @@ export const consoleRouter = router({
         },
       ];
     }),
+  }),
+
+  /**
+   * Activity logs router for admin console
+   * Returns activity/audit logs for system monitoring
+   *
+   * Note: Currently returns empty arrays as a placeholder.
+   * When activity logging is implemented, this will query the activity_logs table.
+   */
+  activityLogs: router({
+    /**
+     * List recent activity logs
+     */
+    list: adminProcedure
+      .input(z.object({ limit: z.number().optional().default(100) }))
+      .query((): ActivityLog[] => {
+        // TODO: Query activity_logs table when implemented
+        // For now, return empty array - UI handles empty state gracefully
+        return [];
+      }),
+
+    /**
+     * Search activity logs by term
+     */
+    search: adminProcedure
+      .input(
+        z.object({
+          searchTerm: z.string(),
+          limit: z.number().optional().default(100),
+        })
+      )
+      .query((): ActivityLog[] => {
+        // TODO: Query activity_logs table with search when implemented
+        // For now, return empty array - UI handles empty state gracefully
+        return [];
+      }),
   }),
 });


### PR DESCRIPTION
Closes #443

## Summary
Add missing console.activityLogs router to unblock @ts-nocheck removal from ConsoleLogs.tsx.

## Changes

### Modified Files
- **server/_core/consoleRouter.ts**: Added activityLogs router with list/search endpoints
  - Returns empty arrays as placeholder (UI handles empty state gracefully)
  - TODO comments mark where to query activity_logs table when implemented
- **client/src/pages/ConsoleLogs.tsx**: Removed @ts-nocheck directive

## Technical Details
The activityLogs router provides:
- list: Returns recent logs with limit parameter
- search: Returns filtered logs by searchTerm

Both currently return empty arrays. When activity logging is implemented, these endpoints will query the database.

## Verification
- [x] pnpm check passes
- [x] pnpm test passes (451 tests)
- [x] ESLint clean on both files