### PR TITLE
[#370] A11y: Add keyboard navigation to clickable districts

### DIFF
--- a/client/src/components/InteractiveMap.tsx
+++ b/client/src/components/InteractiveMap.tsx
@@ -1210,11 +1210,18 @@ export function InteractiveMap({
       if (isHiddenByScope) {
         path.style.cursor = "default";
         path.style.pointerEvents = "none";
+        path.removeAttribute("tabindex");
+        path.removeAttribute("role");
         return; // Skip adding event handlers for hidden districts
       }
 
       path.style.cursor = "pointer";
       path.style.pointerEvents = "auto";
+
+      // A11y: Make district paths keyboard accessible
+      path.setAttribute("tabindex", "0");
+      path.setAttribute("role", "button");
+      path.setAttribute("aria-label", `Select district ${pathId}`);
 
       // Click handler - allow clicking even if district not in database
       const clickHandler = (e: MouseEvent) => {
@@ -1222,6 +1229,16 @@ export function InteractiveMap({
         onDistrictSelect(pathId);
       };
       path.addEventListener("click", clickHandler);
+
+      // A11y: Keyboard handler for Enter/Space activation
+      const keydownHandler = (e: KeyboardEvent) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          e.stopPropagation();
+          onDistrictSelect(pathId);
+        }
+      };
+      path.addEventListener("keydown", keydownHandler);
 
       // Hover behavior: focus district, highlight region, dim others
       const mouseEnterHandler = (e: MouseEvent) => {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -348,3 +348,18 @@
 .scrollbar-hide::-webkit-scrollbar {
   display: none; /* Chrome, Safari, Opera */
 }
+
+/* A11y: Focus styles for interactive SVG district paths */
+svg path[role="button"]:focus {
+  outline: 2px solid #2563eb; /* blue-600 */
+  outline-offset: 2px;
+}
+
+svg path[role="button"]:focus:not(:focus-visible) {
+  outline: none;
+}
+
+svg path[role="button"]:focus-visible {
+  outline: 2px solid #2563eb; /* blue-600 */
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary

Add keyboard accessibility to SVG map district paths, allowing users to navigate and select districts using Tab and Enter/Space keys.

## Changes

- **InteractiveMap.tsx**: Add 	abindex=0, ole=button, ria-label to district paths, plus keydown handler for Enter/Space activation
- **index.css**: Add focus styles for SVG path buttons to show keyboard focus

## Implementation Notes

The issue (#370) mentioned DistrictPanel.tsx, but upon investigation:
- DistrictPanel.tsx's clickable elements already use proper <button> elements with native keyboard support
- The actual accessibility gap was in InteractiveMap.tsx where SVG <path> elements receive click handlers via JavaScript but lacked keyboard accessibility

## Acceptance Criteria

- [x] Districts can be focused with Tab
- [x] Enter/Space activates district
- [x] pnpm check passes

## Evidence

\\\
pnpm check  # ✅ No TypeScript errors
pnpm lint   # ✅ No new errors (only pre-existing warnings)
pnpm test   # ✅ All 451 tests pass
\\\

Closes #370