### PR TITLE
[#480] Remove @ts-nocheck from NationalPanel.tsx

### DIFF
--- a/.github/agents/workspace-ready.signal
+++ b/.github/agents/workspace-ready.signal
@@ -1,5 +1,5 @@
 ﻿{
-    "workspace":  "C:\\Dev\\CMC Go",
-    "timestamp":  "2026-02-04T08:20:57Z",
-    "pid":  41276
+    "workspace":  "C:\\Dev\\CMC-Go-Worktrees\\wt-se",
+    "timestamp":  "2026-02-04T09:23:29Z",
+    "pid":  70784
 }

--- a/client/src/components/NationalPanel.tsx
+++ b/client/src/components/NationalPanel.tsx
@@ -1,8 +1,8 @@
-// @ts-nocheck
 import { X, Plus } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { PersonRow } from "./PersonRow";
-import { useState } from "react";
+import { useState, useMemo } from "react";
+import { Person } from "../../../drizzle/schema";
 import { toast } from "sonner";
 import {
   Dialog,
@@ -24,7 +24,7 @@ import {
 
 interface NationalPanelProps {
   onClose: () => void;
-  onPersonClick: (person: any) => void;
+  onPersonClick: (person: Person) => void;
   onPersonStatusChange: (
     personId: string,
     status: "Yes" | "Maybe" | "No" | "Not Invited"
@@ -178,7 +178,7 @@ export function NationalPanel({
   // Filter out CMC Go Coordinator and Sir James Offord
   const nationalStaff = nationalStaffRaw.filter(p => {
     const nameLower = p.name.toLowerCase();
-    const roleLower = (p.roleTitle || "").toLowerCase();
+    const roleLower = (p.primaryRole || "").toLowerCase();
     return (
       !nameLower.includes("sir james offord") &&
       !roleLower.includes("cmc go coordinator")
@@ -207,8 +207,8 @@ export function NationalPanel({
 
   // Sort people by role priority, then person priority, then name
   const sortedStaff = [...nationalStaff].sort((a, b) => {
-    const rolePriorityA = getRolePriority(a.roleTitle);
-    const rolePriorityB = getRolePriority(b.roleTitle);
+    const rolePriorityA = getRolePriority(a.primaryRole);
+    const rolePriorityB = getRolePriority(b.primaryRole);
 
     if (rolePriorityA !== rolePriorityB) {
       return rolePriorityA - rolePriorityB;
@@ -227,7 +227,7 @@ export function NationalPanel({
   // Group all people into categories
   const groupedStaff = sortedStaff.reduce(
     (acc, person) => {
-      const role = person.roleTitle || "No Role Assigned";
+      const role = person.primaryRole || "No Role Assigned";
       const roleLower = role.toLowerCase();
 
       let category = role;


### PR DESCRIPTION
Closes #480

## Summary
Remove @ts-nocheck directive from NationalPanel.tsx and fix type safety issues.

## Changes
- Removed // @ts-nocheck directive
- Added useMemo import (was already used in the file)
- Added Person type import from drizzle schema
- Fixed onPersonClick prop type from any to Person
- Fixed roleTitle references to primaryRole (correct field name for Person type)

## Verification
- [x] pnpm check passes (no TypeScript errors)
- [x] ESLint passes (no warnings)
- [x] All 451 tests pass