### PR TITLE
[#482] Remove @ts-nocheck from PersonDetailsDialog.tsx

### DIFF
--- a/client/src/components/PersonDetailsDialog.tsx
+++ b/client/src/components/PersonDetailsDialog.tsx
@@ -1,12 +1,10 @@
-// @ts-nocheck
 import { useState } from "react";
-import { Person, Note, Need } from "../../../drizzle/schema";
+import { Person } from "../../../drizzle/schema";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Textarea } from "./ui/textarea";
 import { Label } from "./ui/label";
-import { Switch } from "./ui/switch";
 import {
   Select,
   SelectContent,
@@ -133,9 +131,6 @@ export function PersonDetailsDialog({
     });
   };
 
-  // PR 2: Check if user can view needs (staff can see DISTRICT_VISIBLE needs)
-  const canViewNeeds = isAuthenticated;
-
   // CRITICAL: All hooks must be called before any conditional returns.
   // React requires hooks to be called in the same order on every render.
   // If we return early before calling useIsMobile(), the hook order changes
@@ -202,11 +197,6 @@ export function PersonDetailsDialog({
                       {new Date(change.changedAt).toLocaleString()}
                     </span>
                   </div>
-                  {change.changedBy && (
-                    <div className="text-gray-500 mt-1">
-                      by {change.changedBy}
-                    </div>
-                  )}
                   {change.note && (
                     <div className="text-gray-600 mt-1 italic">
                       {change.note}
@@ -253,7 +243,6 @@ export function PersonDetailsDialog({
                 <p className="text-sm text-gray-900">{note.content}</p>
                 <div className="flex items-center gap-2 mt-2 text-xs text-gray-500">
                   <span>{new Date(note.createdAt).toLocaleDateString()}</span>
-                  {note.createdBy && <span>by {note.createdBy}</span>}
                 </div>
               </div>
             ))


### PR DESCRIPTION
## Summary
Removes \@ts-nocheck\ directive from PersonDetailsDialog.tsx and fixes TypeScript/ESLint issues.

## Changes
- Removed \@ts-nocheck\ directive
- Removed references to undefined \changedBy\ field on StatusChange type (data only has \changedByUserId\)
- Removed references to undefined \createdBy\ field on InviteNote type (data only has \createdByUserId\)
- Removed unused imports: \Note\, \Need\, \Switch\
- Removed unused variable: \canViewNeeds\

## Verification
- \pnpm check\ passes
- \pnpm test\ passes (451 tests)
- ESLint clean (0 warnings)

Closes #482