### PR TITLE
[#493] Remove @ts-nocheck from oauth.ts

### DIFF
--- a/server/_core/oauth.ts
+++ b/server/_core/oauth.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { COOKIE_NAME, ONE_YEAR_MS } from "@shared/const";
 import type { Express, Request, Response } from "express";
 import * as db from "../db";


### PR DESCRIPTION
## Summary
Removes \@ts-nocheck\ directive from server/_core/oauth.ts.

## Changes
- Removed \@ts-nocheck\ directive
- No TypeScript or ESLint errors to fix (code was already type-safe)

## Verification
- \pnpm check\ passes
- \pnpm test\ passes (451 tests)
- ESLint clean

Closes #493