### PR TITLE
[#494] Remove @ts-nocheck from sdk.ts

### DIFF
--- a/server/_core/sdk.ts
+++ b/server/_core/sdk.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { AXIOS_TIMEOUT_MS, COOKIE_NAME, ONE_YEAR_MS } from "@shared/const";
 import { ForbiddenError } from "@shared/_core/errors";
 import axios, { type AxiosInstance } from "axios";


### PR DESCRIPTION
## Summary
Removes @ts-nocheck directive from server/_core/sdk.ts.

## Verification
- pnpm check passes
- pnpm lint passes (0 errors)

Closes #494