### PR TITLE
[#495] Remove @ts-nocheck from db-additions.ts

### DIFF
--- a/server/db-additions.ts
+++ b/server/db-additions.ts
@@ -1,100 +1,12 @@
-// @ts-nocheck
 // Additional DB functions for login and admin features
 // These should be merged into server/db.ts
 
-import { eq, and, gte, isNull } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { users } from "../drizzle/schema";
 
 // ============================================================================
-// USER SESSIONS
+// USER LOGIN
 // ============================================================================
-
-export async function createOrUpdateSession(session: {
-  userId: number;
-  sessionId: string;
-  userAgent: string | null;
-  ipAddress: string | null;
-}) {
-  const { getDb } = await import("./db");
-  const db = await getDb();
-  if (!db) throw new Error("Database not available");
-
-  const { userSessions } = await import("../drizzle/schema");
-
-  // Check if session already exists
-  const existing = await db
-    .select()
-    .from(userSessions)
-    .where(eq(userSessions.sessionId, session.sessionId))
-    .limit(1);
-
-  if (existing.length > 0) {
-    // Update lastSeenAt
-    await db
-      .update(userSessions)
-      .set({ lastSeenAt: new Date() })
-      .where(eq(userSessions.id, existing[0].id));
-    return existing[0];
-  } else {
-    // Create new session
-    const result = await db.insert(userSessions).values({
-      userId: session.userId,
-      sessionId: session.sessionId,
-      userAgent: session.userAgent,
-      ipAddress: session.ipAddress,
-      lastSeenAt: new Date(),
-    });
-
-    return { id: Number(result[0]?.insertId), ...session };
-  }
-}
-
-export async function updateSessionLastSeen(sessionId: string) {
-  const { getDb } = await import("./db");
-  const db = await getDb();
-  if (!db) throw new Error("Database not available");
-
-  const { userSessions } = await import("../drizzle/schema");
-
-  await db
-    .update(userSessions)
-    .set({ lastSeenAt: new Date() })
-    .where(eq(userSessions.sessionId, sessionId));
-}
-
-export async function revokeSession(sessionId: string) {
-  const { getDb } = await import("./db");
-  const db = await getDb();
-  if (!db) throw new Error("Database not available");
-
-  const { userSessions } = await import("../drizzle/schema");
-
-  await db
-    .update(userSessions)
-    .set({ revokedAt: new Date() })
-    .where(eq(userSessions.sessionId, sessionId));
-}
-
-export async function getActiveSessions() {
-  const { getDb } = await import("./db");
-  const db = await getDb();
-  if (!db) return [];
-
-  const { userSessions } = await import("../drizzle/schema");
-
-  // Active = lastSeenAt within 30 minutes and not revoked
-  const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000);
-
-  return await db
-    .select()
-    .from(userSessions)
-    .where(
-      and(
-        gte(userSessions.lastSeenAt, thirtyMinutesAgo),
-        isNull(userSessions.revokedAt)
-      )
-    );
-}
 
 export async function updateUserLastLogin(userId: number) {
   const { getDb } = await import("./db");


### PR DESCRIPTION
## Summary
Removes the @ts-nocheck directive from server/db-additions.ts and cleans up unused code.

## Changes
- Removed @ts-nocheck directive
- Deleted unused session-related functions: createOrUpdateSession, updateSessionLastSeen, revokeSession, getActiveSessions
- Removed corresponding test cases for deleted functions
- Simplified imports (removed unused and, gte, isNull from drizzle-orm)

## Evidence

pnpm check - TypeScript passes
pnpm test server/db-additions.test.ts - 19 tests pass
pnpm test - 440 tests pass (full suite)
npx eslint server/db-additions.ts - No warnings

## Why the deletions?
The session functions referenced a userSessions table that does not exist in the schema. These were dead code and were causing the need for @ts-nocheck.

Closes #495