### PR TITLE
[#499] Fix explicit any type in db-health.ts

### DIFF
--- a/server/_core/db-health.ts
+++ b/server/_core/db-health.ts
@@ -307,9 +307,10 @@ async function verifyCriticalColumns(
     `);
 
     const columnRows = asRows(columnsResult);
-    const existingColumns = columnRows.map(
-      (row: any) => row.column_name || row.COLUMN_NAME || ""
-    );
+    const existingColumns = columnRows.map(row => {
+      const r = row as { column_name?: string; COLUMN_NAME?: string };
+      return r.column_name || r.COLUMN_NAME || "";
+    });
 
     for (const col of requiredColumns) {
       if (!existingColumns.includes(col)) {


### PR DESCRIPTION
Fix the ESLint no-explicit-any warning in server/_core/db-health.ts by adding proper type annotation for database query result row.

Changes:
- Replace (row: any) with properly typed inline cast for column_name/COLUMN_NAME fields

Evidence:
- pnpm check: TypeScript passes
- pnpm test server/db-health.test.ts: 6 tests pass
- npx eslint server/_core/db-health.ts: No warnings

Closes #499