### PR TITLE
[#505] Remove unused lucide-react imports from Home.mobile.tsx

### DIFF
--- a/design/mobile/Home.mobile.tsx
+++ b/design/mobile/Home.mobile.tsx
@@ -9,15 +9,10 @@ import { Button } from "@/components/ui/button";
 import { Person } from "../../../drizzle/schema";
 import {
   MapPin,
-  Calendar,
   Pencil,
   Search,
   X,
   Share2,
-  Copy,
-  Mail,
-  MessageCircle,
-  Check,
   Upload,
   Menu,
   LogIn,


### PR DESCRIPTION
## Summary
Removes 5 unused lucide-react icon imports from the mobile design prototype file.

## Changes
- Removed: Calendar, Copy, Mail, MessageCircle, Check

## Note
Other unused variables exist in this file (15 warnings total), but this is a design prototype not imported in production code. The icon imports were the ones flagged in the original issue.

## Verification
- \pnpm check\: ✅ TypeScript compiles
- Lint warnings reduced from 71 to 66

Closes #505