### PR TITLE
[#506] Remove unreachable if(false) dead code blocks

### DIFF
--- a/client/src/components/PersonRow.tsx
+++ b/client/src/components/PersonRow.tsx
@@ -94,18 +94,6 @@ export function PersonRow({
     onStatusChange(person.personId, nextStatus);
   };
 
-  // Authentication disabled - always show full person row
-  if (false) {
-    return (
-      <div className="flex items-center gap-1.5 bg-slate-50 rounded-lg border border-slate-200 pointer-events-none">
-        <div className="w-1.5 h-8 rounded-l bg-slate-400 opacity-30 flex-shrink-0" />
-        <div className="flex-1 py-1.5 pr-2 min-w-0">
-          <div className="w-16 h-3 bg-slate-300 opacity-30 rounded" />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div
       ref={setNodeRef}

--- a/client/src/pages/Import.tsx
+++ b/client/src/pages/Import.tsx
@@ -60,20 +60,6 @@ export default function Import() {
     );
   }
 
-  // Authentication disabled - allow all users to import
-  if (false) {
-    return (
-      <div className="container max-w-4xl py-8">
-        <Card>
-          <CardHeader>
-            <CardTitle>Access Denied</CardTitle>
-            <CardDescription>Only leaders can import data.</CardDescription>
-          </CardHeader>
-        </Card>
-      </div>
-    );
-  }
-
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0];
     if (selectedFile) {

--- a/client/src/pages/Needs.tsx
+++ b/client/src/pages/Needs.tsx
@@ -85,20 +85,6 @@ export default function Needs() {
     );
   }
 
-  // Authentication disabled - allow all users to view needs
-  if (false) {
-    return (
-      <div className="container max-w-4xl py-8">
-        <Card>
-          <CardHeader>
-            <CardTitle>Access Denied</CardTitle>
-            <CardDescription>Please log in to view requests.</CardDescription>
-          </CardHeader>
-        </Card>
-      </div>
-    );
-  }
-
   return (
     <div className="container max-w-6xl py-8">
       <div className="flex items-center justify-between mb-6">


### PR DESCRIPTION
## Summary
Removes 3 unreachable code blocks guarded by \if (false)\ that were leftover from when authentication was disabled.

## Changes
Removed ~40 lines of dead code that could never execute:

- **PersonRow.tsx** - Removed placeholder row render (lines 98-107)
- **Import.tsx** - Removed 'Access Denied' render (lines 64-76)  
- **Needs.tsx** - Removed 'Access Denied' render (lines 89-101)

## Context
These blocks rendered 'Access Denied' or placeholder UI that was unreachable since the condition is always false.

## Verification
- \pnpm check\: ✅ TypeScript compiles
- \pnpm lint\: ✅ No more 'no-constant-condition' warnings
- Lint warnings reduced by 3

Closes #506