### PR TITLE
feat: Add Campus button in registration + auto-open district on login

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -629,6 +629,13 @@ export default function Home() {
     setPersonDialogOpen(true);
   };
 
+  // After login/register, auto-open the user's district panel
+  const handleAuthSuccess = (districtId: string | null) => {
+    if (districtId) {
+      handleDistrictSelect(districtId);
+    }
+  };
+
   // Keyboard shortcuts for district panel
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -1431,7 +1438,11 @@ export default function Home() {
         onClose={() => setShareModalOpen(false)}
       />
       <ImportModal open={importModalOpen} onOpenChange={setImportModalOpen} />
-      <LoginModal open={loginModalOpen} onOpenChange={setLoginModalOpen} />
+      <LoginModal
+        open={loginModalOpen}
+        onOpenChange={setLoginModalOpen}
+        onAuthSuccess={handleAuthSuccess}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Changes

### 1. Add Campus button during registration
When a user searches for their campus and it's not found, they can now create it on the spot:
- Shows **Add \<campus name>\ as new campus** button when search has no exact match
- Uses the existing \campuses.createPublic\ endpoint to create the campus
- Campus is automatically added to the correct district
- User flows seamlessly into role selection after adding

### 2. Auto-create person record on registration
- When a new user registers, a person record is automatically created in the \people\ table
- This makes the user immediately visible in the district panel with person icons
- The person is linked to the user via \linkedPersonId\
- Non-fatal: if person creation fails, registration still succeeds

### 3. Auto-open user's district panel on login
- After login or registration, the app automatically navigates to the user's district
- The district panel opens showing their campuses and people
- This is the most likely place the user wants to be after logging in

### 4. Remove password minimum (8 char) on register/resetPassword
- Server-side \min(8)\ changed to \min(1)\ on both endpoints
- Aligns with the client-side change already deployed

### Testing
- [x] TypeScript compiles cleanly
- [x] Production login returns 401 (not 500)
- [x] Production registration returns 200
- [x] Pre-existing test failures only (Vite SSR environment issue)
