### PR TITLE
Deploy: Add Campus registration + district auto-open + person auto-create

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -629,6 +629,13 @@ export default function Home() {
     setPersonDialogOpen(true);
   };
 
+  // After login/register, auto-open the user's district panel
+  const handleAuthSuccess = (districtId: string | null) => {
+    if (districtId) {
+      handleDistrictSelect(districtId);
+    }
+  };
+
   // Keyboard shortcuts for district panel
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -1431,7 +1438,11 @@ export default function Home() {
         onClose={() => setShareModalOpen(false)}
       />
       <ImportModal open={importModalOpen} onOpenChange={setImportModalOpen} />
-      <LoginModal open={loginModalOpen} onOpenChange={setLoginModalOpen} />
+      <LoginModal
+        open={loginModalOpen}
+        onOpenChange={setLoginModalOpen}
+        onAuthSuccess={handleAuthSuccess}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Deploys staging to main for Railway deployment.

## Changes (from PR #516)
- **Add Campus button** in registration when campus not found
- **Auto-create person record** on registration (user appears in district panel)
- **Auto-open user's district** panel after login/registration
- **Remove min(8) password** validation on register + resetPassword endpoints

Closes #516