### PR TITLE
fix: bust Railway build cache, redeploy all UI+auth fixes

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -4,16 +4,17 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Deploy to Railway
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           npm install -g @railway/cli
-          railway up --service 97d10b0b-dcf8-4df8-816b-13d61ccfaa3b
+          railway up --service 97d10b0b-dcf8-4df8-816b-13d61ccfaa3b --no-cache


### PR DESCRIPTION
## Changes
- Add \--no-cache\ flag to \ailway up\ to prevent stale Vite build output from being cached
- Upgrade \ctions/checkout@v3\ to \@v4\`n- Add \workflow_dispatch\ trigger for manual redeployment

## Context
Railway's railpack build system was caching the Vite client bundle, causing production to serve stale JS/CSS while the server-side code was updated correctly. This resulted in:
- Old UI code (including \ACTION NEEDED\ labels, old login text)
- A TDZ crash (\ReferenceError: Cannot access before initialization\) in the district panel

All fixes from PRs #522, #524, #525 are in main but the stale client bundle prevented them from reaching users.