### PR TITLE
fix: Railway deploy cache buster + workflow dispatch

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -17,4 +17,6 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           npm install -g @railway/cli
-          railway up --service 97d10b0b-dcf8-4df8-816b-13d61ccfaa3b --no-cache
+          # Write commit SHA to bust railpack build cache
+          echo "$GITHUB_SHA" > .build-version
+          railway up --service 97d10b0b-dcf8-4df8-816b-13d61ccfaa3b


### PR DESCRIPTION
Fixes deployment issue where Railway's railpack build cache was serving stale client bundles.

Changes:
- Write \\\ to \.build-version\ to invalidate railpack layer cache
- Upgrade actions/checkout to v4
- Add workflow_dispatch for manual redeployment

The server-side code deploys correctly (CSP headers are updated) but the Vite client bundle has been frozen at \index-DI6KyH7L.js\ across multiple deployments.