### PR TITLE
fix: crash when opening people panel (TDZ in PeoplePanel useMemo)

### DIFF
--- a/client/src/components/PeoplePanel.tsx
+++ b/client/src/components/PeoplePanel.tsx
@@ -253,6 +253,14 @@ export function PeoplePanel({ onClose }: PeoplePanelProps) {
     })).filter(r => r.districts.length > 0);
   }, [allDistricts, allCampuses]);
 
+  // User's region: either their direct regionId or overseeRegionId
+  // IMPORTANT: This must be declared BEFORE userPeopleScope which references it.
+  const userRegionId =
+    (user as { regionId?: string | null; overseeRegionId?: string | null })
+      ?.regionId ||
+    (user as { overseeRegionId?: string | null })?.overseeRegionId ||
+    null;
+
   // User's effective people-scope for filtering the scope dropdown (mirror server getPeopleScope)
   const userPeopleScope = useMemo(():
     | "ALL"
@@ -286,7 +294,7 @@ export function PeoplePanel({ onClose }: PeoplePanelProps) {
     if (["STAFF", "CO_DIRECTOR"].includes(role) && cId != null)
       return { level: "CAMPUS", campusId: cId };
     return "ALL";
-  }, [user]);
+  }, [user, userRegionId]);
 
   // Scope menu tree filtered to what the user is authorized to see
   const scopeMenuTreeFiltered = useMemo(() => {
@@ -336,11 +344,6 @@ export function PeoplePanel({ onClose }: PeoplePanelProps) {
         String(user.role)
       ))
   );
-  const userRegionId =
-    (user as { regionId?: string | null; overseeRegionId?: string | null })
-      ?.regionId ||
-    (user as { overseeRegionId?: string | null })?.overseeRegionId ||
-    null;
 
   const scopeFilterLabel = scopeFilterPersonId
     ? (allPeople.find((p: Person) => p.personId === scopeFilterPersonId)


### PR DESCRIPTION
## Bug
Clicking on the people/table panel after login caused:
ReferenceError: Cannot access 'jt' before initialization at Object.useMemo

## Root Cause
In PeoplePanel.tsx, the userPeopleScope useMemo (line 257) referenced userRegionId, but userRegionId was declared later at line 340. Since useMemo callbacks execute synchronously during render, accessing a const variable before its declaration causes a ReferenceError (Temporal Dead Zone).

## Fix
Moved userRegionId declaration BEFORE the userPeopleScope useMemo and added it to the dependency array.