### PR TITLE
Deploy: Import to kebab menu, XAN scope/aggregate fixes, Regional access

### DIFF
--- a/client/src/components/InteractiveMap.tsx
+++ b/client/src/components/InteractiveMap.tsx
@@ -2087,7 +2087,8 @@ export function InteractiveMap({
         {/* Pie charts layer - removed per user request */}
 
         {/* XAN National Button - Positioned absolutely, transforms with map */}
-        {!selectedDistrictId && (
+        {/* Only visible on National Scope */}
+        {!selectedDistrictId && scopeFilter === "NATIONAL" && (
           <div
             className="absolute inset-0 flex items-center justify-center z-40 pointer-events-none"
             style={{

--- a/client/src/components/PeoplePanel.tsx
+++ b/client/src/components/PeoplePanel.tsx
@@ -2,9 +2,11 @@ import { trpc } from "@/lib/trpc";
 import { useState, useMemo, useCallback } from "react";
 import { Person, District, Campus } from "../../../drizzle/schema";
 import { PersonDetailsDialog } from "./PersonDetailsDialog";
+import { ImportModal } from "./ImportModal";
 import {
   X,
   Download,
+  Upload,
   Search,
   Filter,
   ChevronDown,
@@ -40,6 +42,7 @@ interface PeoplePanelProps {
 export function PeoplePanel({ onClose }: PeoplePanelProps) {
   const [selectedPerson, setSelectedPerson] = useState<Person | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [importModalOpen, setImportModalOpen] = useState(false);
   const { isAuthenticated: _isAuthenticated } = usePublicAuth();
   const { user } = useAuth();
   const _utils = trpc.useUtils();
@@ -1538,6 +1541,10 @@ export function PeoplePanel({ onClose }: PeoplePanelProps) {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => setImportModalOpen(true)}>
+                <Upload className="h-4 w-4" />
+                Import
+              </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={handleExport}
                 disabled={scopeFilteredPeople.length === 0}
@@ -2014,6 +2021,7 @@ export function PeoplePanel({ onClose }: PeoplePanelProps) {
         open={dialogOpen}
         onOpenChange={setDialogOpen}
       />
+      <ImportModal open={importModalOpen} onOpenChange={setImportModalOpen} />
     </div>
   );
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -23,7 +23,6 @@ import {
   Mail,
   MessageCircle,
   Check,
-  Upload,
   Menu,
   LogIn,
   LogOut,
@@ -32,7 +31,6 @@ import {
 import { ImageCropModal } from "@/components/ImageCropModal";
 import { HeaderEditorModal } from "@/components/HeaderEditorModal";
 import { ShareModal } from "@/components/ShareModal";
-import { ImportModal } from "@/components/ImportModal";
 import { NationalPanel } from "@/components/NationalPanel";
 import { LoginModal } from "@/components/LoginModal";
 import { ScopeSelector, useScopeFilter } from "@/components/ScopeSelector";
@@ -180,7 +178,7 @@ export default function Home() {
   const [cropModalOpen, setCropModalOpen] = useState(false);
   const [selectedImageSrc, setSelectedImageSrc] = useState<string>("");
   const [selectedFileName, setSelectedFileName] = useState<string>("");
-  const [importModalOpen, setImportModalOpen] = useState(false);
+
   const [menuOpen, setMenuOpen] = useState(false);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -653,9 +651,8 @@ export default function Home() {
           return;
         }
         // Close all hamburger menu related modals and menu
-        if (shareModalOpen || importModalOpen || loginModalOpen || menuOpen) {
+        if (shareModalOpen || loginModalOpen || menuOpen) {
           if (shareModalOpen) setShareModalOpen(false);
-          if (importModalOpen) setImportModalOpen(false);
           if (loginModalOpen) setLoginModalOpen(false);
           if (menuOpen) setMenuOpen(false);
           e.preventDefault();
@@ -725,7 +722,6 @@ export default function Home() {
     headerEditorOpen,
     shareModalOpen,
     cropModalOpen,
-    importModalOpen,
     loginModalOpen,
     menuOpen,
     districts,
@@ -985,18 +981,6 @@ export default function Home() {
                     <Share2 className="w-5 h-5 sm:w-4 sm:h-4" />
                     Share
                   </button>
-                  <button
-                    onClick={e => {
-                      e.stopPropagation();
-                      setImportModalOpen(true);
-                      setMenuOpen(false);
-                    }}
-                    className="w-full px-4 py-3 sm:py-2 text-left text-sm text-black hover:bg-red-600 hover:text-white active:bg-red-700 flex items-center gap-3 transition-colors"
-                  >
-                    <Upload className="w-5 h-5 sm:w-4 sm:h-4" />
-                    Import
-                  </button>
-
                   <button
                     onClick={e => {
                       e.stopPropagation();
@@ -1437,7 +1421,6 @@ export default function Home() {
         open={shareModalOpen}
         onClose={() => setShareModalOpen(false)}
       />
-      <ImportModal open={importModalOpen} onOpenChange={setImportModalOpen} />
       <LoginModal
         open={loginModalOpen}
         onOpenChange={setLoginModalOpen}

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -43,9 +43,9 @@ function getDefaultAuthorization(role: string) {
     case "REGION_DIRECTOR":
     case "REGIONAL_STAFF":
       return {
-        scopeLevel: "REGION" as const,
+        scopeLevel: "NATIONAL" as const, // Can access National scope to see everything
         viewLevel: "NATIONAL" as const,
-        editLevel: "REGION" as const,
+        editLevel: "REGION" as const, // Can only edit their region
       };
 
     case "DISTRICT_DIRECTOR":


### PR DESCRIPTION
## Summary

- Move Import button from toolbar hamburger menu to PeoplePanel kebab menu (above Export)
- XAN button only visible when scope is NATIONAL
- XAN-role people (National Team) now count in XAN district aggregates
- REGION_DIRECTOR and REGIONAL_STAFF get scopeLevel NATIONAL (can see all) with editLevel REGION (can only edit their region)