### PR TITLE
fix(auth): align getPeopleScope with 3-tier authorization spec

### DIFF
--- a/scripts/seed-admin.mjs
+++ b/scripts/seed-admin.mjs
@@ -70,9 +70,14 @@ async function main() {
           "sirjamesoffordII@gmail.com",
           passwordHash,
           "CMC_GO_ADMIN",
-          "NATIONAL", "NATIONAL", "NATIONAL",
-          null, null, null,
-          "ACTIVE", false,
+          "NATIONAL",
+          "NATIONAL",
+          "NATIONAL",
+          null,
+          null,
+          null,
+          "ACTIVE",
+          false,
         ]
       );
       console.log("✅ CMC Go Admin account created successfully");
@@ -84,7 +89,9 @@ async function main() {
       ["Arodriguez@ag.org"]
     );
     if (Array.isArray(existingAlex) && existingAlex.length > 0) {
-      console.log("✅ Alex Rodriguez (National Director) already exists (skipping)");
+      console.log(
+        "✅ Alex Rodriguez (National Director) already exists (skipping)"
+      );
     } else {
       const alexHash = await hashPassword("National Director");
       await connection.execute(
@@ -99,9 +106,14 @@ async function main() {
           "Arodriguez@ag.org",
           alexHash,
           "NATIONAL_DIRECTOR",
-          "NATIONAL", "NATIONAL", "NATIONAL",
-          null, null, null,
-          "ACTIVE", false,
+          "NATIONAL",
+          "NATIONAL",
+          "NATIONAL",
+          null,
+          null,
+          null,
+          "ACTIVE",
+          false,
         ]
       );
       console.log("✅ Alex Rodriguez (National Director) created");
@@ -128,9 +140,14 @@ async function main() {
           "dan@nwxa.org",
           danHash,
           "FIELD_DIRECTOR",
-          "NATIONAL", "NATIONAL", "NATIONAL",
-          null, null, null,
-          "ACTIVE", false,
+          "NATIONAL",
+          "NATIONAL",
+          "NATIONAL",
+          null,
+          null,
+          null,
+          "ACTIVE",
+          false,
         ]
       );
       console.log("✅ Dan Guenther (Field Director) created");
@@ -142,7 +159,9 @@ async function main() {
       ["mkhoogendoorn@gmail.com"]
     );
     if (Array.isArray(existingMatt) && existingMatt.length > 0) {
-      console.log("✅ Matthew Hoogendoorn (Regional Director, Texico) already exists (skipping)");
+      console.log(
+        "✅ Matthew Hoogendoorn (Regional Director, Texico) already exists (skipping)"
+      );
     } else {
       const mattHash = await hashPassword("Regional Director");
       await connection.execute(
@@ -157,9 +176,15 @@ async function main() {
           "mkhoogendoorn@gmail.com",
           mattHash,
           "REGION_DIRECTOR",
-          "NATIONAL", "NATIONAL", "REGION",
-          null, null, "Texico", "Texico",
-          "ACTIVE", false,
+          "NATIONAL",
+          "NATIONAL",
+          "REGION",
+          null,
+          null,
+          "Texico",
+          "Texico",
+          "ACTIVE",
+          false,
         ]
       );
       console.log("✅ Matthew Hoogendoorn (Regional Director, Texico) created");
@@ -186,9 +211,14 @@ async function main() {
           "Admin@cmcgo.app",
           demoHash,
           "CMC_GO_ADMIN",
-          "NATIONAL", "NATIONAL", "NATIONAL",
-          null, null, null,
-          "ACTIVE", false,
+          "NATIONAL",
+          "NATIONAL",
+          "NATIONAL",
+          null,
+          null,
+          null,
+          "ACTIVE",
+          false,
         ]
       );
       console.log("✅ Admin@cmcgo.app (CMC_GO_ADMIN) created");

--- a/scripts/seed-texas-new-mexico.mjs
+++ b/scripts/seed-texas-new-mexico.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+/**
+ * Seed script to add Texas and New Mexico campuses and people
+ * Run with: node scripts/seed-texas-new-mexico.mjs
+ */
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/mysql2";
+import mysql from "mysql2/promise";
+import { campuses, people, districts } from "../drizzle/schema.ts";
+import { eq, and } from "drizzle-orm";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error("DATABASE_URL not set");
+  process.exit(1);
+}
+
+const connection = await mysql.createConnection(DATABASE_URL);
+const db = drizzle(connection);
+
+// Districts to ensure exist
+const DISTRICTS = [
+  { id: "SouthTexas", name: "South Texas", region: "Texico" },
+  { id: "NorthTexas", name: "North Texas", region: "Texico" },
+  { id: "WestTexas", name: "West Texas", region: "Texico" },
+  { id: "NewMexico", name: "New Mexico", region: "Texico" },
+];
+
+// Data structure: { districtId: { campusName: [people] } }
+const DATA = {
+  SouthTexas: {
+    _districtDirector: "Jake Lefner",
+    "University of Houston": [
+      { name: "Matthew Hoogendorn", role: "Campus Director" },
+    ],
+    "Sam Houston State University": [
+      { name: "Colin Weezer", role: "Campus Director" },
+    ],
+    "Lamar University": [{ name: "Andy Jirrels", role: "Campus Director" }],
+    "Prairie View A&M University": [
+      { name: "Sir James Offord", role: "Campus Director" },
+      { name: "Moriah Offord", role: "Campus Co-Director" },
+      { name: "Cam", role: "Staff" },
+      { name: "Jada", role: "Staff" },
+      { name: "Zoe", role: "Staff" },
+      { name: "Destiny", role: "Staff" },
+    ],
+    "University of Texas at San Antonio": [
+      { name: "Johnny Hauk", role: "Campus Director" },
+      { name: "Amy Hauk", role: "Campus Co-Director" },
+    ],
+    "Texas A&M University-Kingsville": [
+      { name: "Makaela Waters", role: "Campus Director" },
+    ],
+    "Texas A&M University-Corpus Christi": [
+      { name: "Derrick Bruce", role: "Campus Director" },
+      { name: "Marrisa Bruce", role: "Campus Co-Director" },
+    ],
+    "University of Texas Rio Grande Valley (Brownsville)": [
+      { name: "Dane", role: "Campus Director" },
+    ],
+  },
+  NorthTexas: {
+    _districtDirector: "Dick Herman",
+    "Texas Christian University": [
+      { name: "Andrew Youngblood", role: "Campus Director" },
+      { name: "Alicia Youngblood", role: "Campus Co-Director" },
+    ],
+    "University of North Texas": [{ name: "Haley", role: "Campus Director" }],
+    "Texas Woman's University": [{ name: "Alyssa", role: "Campus Director" }],
+    "University of Texas at Arlington": [],
+    "University of Texas at Austin": [],
+    "Texas State University": [{ name: "Paige", role: "Campus Director" }],
+    "Stephen F. Austin State University": [
+      { name: "Derrick", role: "Campus Director" },
+    ],
+    "Midwestern State University": [
+      { name: "Kristin", role: "Campus Director" },
+    ],
+    "Angelo State University": [{ name: "Scroggins", role: "Campus Director" }],
+  },
+  WestTexas: {
+    _districtDirector: "Renay Little",
+    "Texas Tech University": [{ name: "Nick Hester", role: "Campus Director" }],
+    "West Texas A&M University": [{ name: "Joshua", role: "Campus Director" }],
+  },
+  NewMexico: {
+    _districtDirector: "Justin Vistine",
+    "New Mexico Highlands University": [
+      { name: "Cooper", role: "Campus Director" },
+    ],
+    "Eastern New Mexico University": [
+      { name: "Justin Vinstine", role: "Campus Director" },
+    ],
+  },
+};
+
+// Generate unique personId
+function generatePersonId(name, districtId, campusName) {
+  const cleanName = name.replace(/[^a-zA-Z]/g, "").toLowerCase();
+  const cleanCampus = campusName
+    ? campusName
+        .replace(/[^a-zA-Z]/g, "")
+        .substring(0, 10)
+        .toLowerCase()
+    : "district";
+  return `${districtId.toLowerCase()}-${cleanCampus}-${cleanName}-${Date.now().toString(36)}`;
+}
+
+async function ensureDistrictsExist() {
+  console.log("Ensuring districts exist...");
+  for (const district of DISTRICTS) {
+    const existing = await db
+      .select()
+      .from(districts)
+      .where(eq(districts.id, district.id));
+    if (existing.length === 0) {
+      await db.insert(districts).values(district);
+      console.log(`  Created district: ${district.name}`);
+    } else {
+      console.log(`  District exists: ${district.name}`);
+    }
+  }
+}
+
+async function getOrCreateCampus(campusName, districtId) {
+  // Check if campus already exists
+  const existing = await db
+    .select()
+    .from(campuses)
+    .where(
+      and(eq(campuses.name, campusName), eq(campuses.districtId, districtId))
+    );
+
+  if (existing.length > 0) {
+    console.log(`  Campus exists: ${campusName} (id=${existing[0].id})`);
+    return existing[0].id;
+  }
+
+  // Create new campus
+  const result = await db.insert(campuses).values({
+    name: campusName,
+    districtId: districtId,
+    displayOrder: 0,
+  });
+
+  const insertId = result[0].insertId;
+  console.log(`  Created campus: ${campusName} (id=${insertId})`);
+  return insertId;
+}
+
+async function createPersonIfNotExists(
+  personData,
+  campusId,
+  districtId,
+  region
+) {
+  // Check if person with same name exists in same campus/district
+  const existing = await db
+    .select()
+    .from(people)
+    .where(
+      and(
+        eq(people.name, personData.name),
+        eq(people.primaryDistrictId, districtId),
+        campusId ? eq(people.primaryCampusId, campusId) : undefined
+      )
+    );
+
+  if (existing.length > 0) {
+    console.log(`    Person exists: ${personData.name}`);
+    return;
+  }
+
+  const personId = generatePersonId(
+    personData.name,
+    districtId,
+    campusId ? "campus" : null
+  );
+
+  await db.insert(people).values({
+    personId,
+    name: personData.name,
+    primaryRole: personData.role,
+    primaryCampusId: campusId,
+    primaryDistrictId: districtId,
+    primaryRegion: region,
+    status: "Not Invited",
+  });
+
+  console.log(`    Created person: ${personData.name} (${personData.role})`);
+}
+
+async function main() {
+  console.log(
+    "Starting seed for Texas and New Mexico campuses and people...\n"
+  );
+
+  await ensureDistrictsExist();
+  console.log("");
+
+  for (const [districtId, districtData] of Object.entries(DATA)) {
+    const district = DISTRICTS.find(d => d.id === districtId);
+    console.log(`\n=== ${district.name} ===`);
+
+    // Add district director
+    if (districtData._districtDirector) {
+      console.log(
+        `  Adding District Director: ${districtData._districtDirector}`
+      );
+      await createPersonIfNotExists(
+        { name: districtData._districtDirector, role: "District Director" },
+        null, // no campus for district director
+        districtId,
+        district.region
+      );
+    }
+
+    // Add campuses and their people
+    for (const [campusName, peopleList] of Object.entries(districtData)) {
+      if (campusName.startsWith("_")) continue; // Skip meta fields
+
+      console.log(`\n  Campus: ${campusName}`);
+      const campusId = await getOrCreateCampus(campusName, districtId);
+
+      for (const person of peopleList) {
+        await createPersonIfNotExists(
+          person,
+          campusId,
+          districtId,
+          district.region
+        );
+      }
+    }
+  }
+
+  console.log("\n✅ Seed complete!");
+  await connection.end();
+}
+
+main().catch(err => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/server/peopleScope.failClosed.test.ts
+++ b/server/peopleScope.failClosed.test.ts
@@ -59,15 +59,15 @@ function createTestContext(
 }
 
 describe("getPeopleScope fail-closed (missing anchors)", () => {
-  it("STAFF without campusId -> FORBIDDEN", () => {
+  it("STAFF without regionId -> FORBIDDEN", () => {
     expectForbiddenSync(() =>
-      getPeopleScope({ role: "STAFF", campusId: null })
+      getPeopleScope({ role: "STAFF", campusId: 1, regionId: null })
     );
   });
 
-  it("CAMPUS_DIRECTOR without districtId -> FORBIDDEN (even if campusId present)", () => {
+  it("CAMPUS_DIRECTOR without regionId -> FORBIDDEN (even if districtId present)", () => {
     expectForbiddenSync(() =>
-      getPeopleScope({ role: "CAMPUS_DIRECTOR", campusId: 1, districtId: null })
+      getPeopleScope({ role: "CAMPUS_DIRECTOR", campusId: 1, districtId: "D1", regionId: null })
     );
   });
 
@@ -81,19 +81,20 @@ describe("getPeopleScope fail-closed (missing anchors)", () => {
     );
   });
 
-  it("unmapped role -> FORBIDDEN", () => {
+  it("unmapped role without regionId -> FORBIDDEN", () => {
     expectForbiddenSync(() =>
-      getPeopleScope({ role: "SOME_UNKNOWN_ROLE", campusId: 1 })
+      getPeopleScope({ role: "SOME_UNKNOWN_ROLE", campusId: 1, regionId: null })
     );
   });
 });
 
 describe("API fail-closed (bad user state)", () => {
-  it("peopleScope rejects CAMPUS_DIRECTOR without districtId", async () => {
+  it("peopleScope rejects CAMPUS_DIRECTOR without regionId", async () => {
     const ctx = createTestContext({
       role: "CAMPUS_DIRECTOR" as any,
       campusId: 1,
       districtId: null,
+      regionId: null,
     });
 
     const caller = testRouter.createCaller(ctx);
@@ -111,10 +112,11 @@ describe("API fail-closed (bad user state)", () => {
     await expectForbidden(caller.peopleScope());
   });
 
-  it("peopleScope rejects unmapped roles", async () => {
+  it("peopleScope rejects unmapped roles without regionId", async () => {
     const ctx = createTestContext({
       role: "SOME_UNKNOWN_ROLE" as any,
       campusId: 1,
+      regionId: null,
     });
 
     const caller = testRouter.createCaller(ctx);

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -115,10 +115,7 @@ const ROLES_REQUIRING_OVERSEE_REGION = [
 ] as const;
 
 // Roles that require admin approval before access is granted
-const ROLES_REQUIRING_APPROVAL = [
-  "REGION_DIRECTOR",
-  "REGIONAL_STAFF",
-] as const;
+const ROLES_REQUIRING_APPROVAL = ["REGION_DIRECTOR", "REGIONAL_STAFF"] as const;
 
 export const appRouter = router({
   system: systemRouter,
@@ -345,7 +342,9 @@ export const appRouter = router({
           regionId,
           overseeRegionId,
           ...authLevels,
-          approvalStatus: (ROLES_REQUIRING_APPROVAL as readonly string[]).includes(input.role)
+          approvalStatus: (
+            ROLES_REQUIRING_APPROVAL as readonly string[]
+          ).includes(input.role)
             ? "PENDING_APPROVAL"
             : "ACTIVE",
         });


### PR DESCRIPTION
## Changes

- Refactored \getPeopleScope()\ to use \scopeLevel\ DB field with role-based fallback
- Campus roles (STAFF, CO_DIRECTOR, CAMPUS_DIRECTOR, etc.) now correctly return REGION scope per authorization spec
- Added \getScopeLevelFallback()\ for role-based defaults when DB field is missing
- Updated all authorization tests (396 passing, 0 TS errors)
- Reformatted seed-admin.mjs
- Added seed-texas-new-mexico.mjs for region/district seeding

## Verification

- \pnpm check\ — 0 TypeScript errors
- \pnpm test\ — 396 tests passing
- Authorization spec alignment verified for all 14 roles