### PR TITLE
Stop generating fake emails/phones

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,48 +6,49 @@ This directory contains scripts for database management, agent automation, data 
 
 ## Quick Reference
 
-| Script                       | Category   | Purpose                                                           |
-| ---------------------------- | ---------- | ----------------------------------------------------------------- |
-| `seed-database.mjs`          | Database   | Comprehensive seeding (districts, campuses, people, needs, notes) |
-| `reset-db.mjs`               | Database   | Drop all tables and reseed (with production safeguards)           |
-| `reset-local-db.mjs`         | Database   | Safe local-only database reset with multiple safety checks        |
-| `db-push-yes.mjs`            | Database   | Non-interactive drizzle-kit push wrapper                          |
-| `run-migrations.mjs`         | Database   | Execute SQL migration files in order                              |
-| `init-mysql-db.mjs`          | Database   | Initialize MySQL database connection                              |
-| `seed-baseline.mjs`          | Database   | Seed only required baseline data (idempotent)                     |
-| `seed-chi-alpha.mjs`         | Database   | Seed Chi Alpha regions and districts                              |
-| `seed-regions-districts.mjs` | Database   | Seed regions and districts with colors                            |
-| `seed-mysql-dev.mjs`         | Database   | Seed MySQL dev environment                                        |
-| `populate-contacts.mjs`      | Database   | Sync verified emails into people (no fabrication)                 |
-| `reseed-districts.mjs`       | Database   | Re-seed districts matching SVG map IDs                            |
-| `verify-database.mjs`        | Validation | Verify database schema matches expected structure                 |
-| `verify-write.mjs`           | Validation | Test create/update operations persist correctly                   |
-| `audit-migrations.mjs`       | Validation | Audit migration files against current schema                      |
-| `check-schema.mjs`           | Validation | Check critical tables and columns exist                           |
-| `check-map-data.mjs`         | Validation | Verify map data (districts, people, campuses)                     |
-| `validate-agents.mjs`        | Validation | Validate agent and prompt YAML frontmatter                        |
-| `import-from-export.mjs`     | Import     | Import data from exported JSON files                              |
-| `ingest-excel.mjs`           | Import     | Ingest Excel seed data with sanitization                          |
-| `agent-login-gh.ps1`         | Agent      | Interactive GitHub login for agent accounts                       |
-| `agent-quick.ps1`            | Agent      | Quick agent operations (worktree, PR, issue comment)              |
-| `create-agent-issues.ps1`    | Agent      | Create GitHub issues (URL, CLI, or REST API)                      |
-| `clear-github-token.ps1`     | Agent      | Remove stored GitHub token                                        |
-| `gh-as.ps1`                  | Agent      | Run `gh` commands as a specific agent account                     |
-| `git-grep.ps1`               | Agent      | Fast search over git-tracked files (avoids recursion hangs)       |
-| `git-credential-gh.ps1`      | Agent      | Git credential helper for multi-identity                          |
-| `set-gh-secret.ps1`          | Agent      | Set GitHub repository secrets                                     |
-| `setup-agent-identities.ps1` | Agent      | Configure git identities for agent worktrees                      |
-| `spawn-parallel-agents.ps1`  | Agent      | Spawn multiple VS Code agent sessions                             |
-| `spawn-worktree-agent.ps1`   | Agent      | Spawn Copilot agent in a new worktree                             |
-| `post-merge-evidence.ps1`    | Agent      | Post merge evidence to GitHub issues                              |
-| `populate-db.sql`            | Data       | SQL script to populate database (legacy)                          |
-| `seed-data.sql`              | Data       | Simple SQL seed script (legacy)                                   |
-| `temp-seed.sql`              | Data       | Temporary seed data SQL                                           |
-| `seed-campuses.json`         | Data       | Campus seed data                                                  |
-| `seed-districts.json`        | Data       | District seed data                                                |
-| `seed-needs.json`            | Data       | Needs seed data                                                   |
-| `seed-notes.json`            | Data       | Notes seed data                                                   |
-| `seed-people.json`           | Data       | People seed data                                                  |
+| Script                            | Category   | Purpose                                                           |
+| --------------------------------- | ---------- | ----------------------------------------------------------------- |
+| `seed-database.mjs`               | Database   | Comprehensive seeding (districts, campuses, people, needs, notes) |
+| `reset-db.mjs`                    | Database   | Drop all tables and reseed (with production safeguards)           |
+| `reset-local-db.mjs`              | Database   | Safe local-only database reset with multiple safety checks        |
+| `db-push-yes.mjs`                 | Database   | Non-interactive drizzle-kit push wrapper                          |
+| `run-migrations.mjs`              | Database   | Execute SQL migration files in order                              |
+| `init-mysql-db.mjs`               | Database   | Initialize MySQL database connection                              |
+| `seed-baseline.mjs`               | Database   | Seed only required baseline data (idempotent)                     |
+| `seed-chi-alpha.mjs`              | Database   | Seed Chi Alpha regions and districts                              |
+| `seed-regions-districts.mjs`      | Database   | Seed regions and districts with colors                            |
+| `seed-mysql-dev.mjs`              | Database   | Seed MySQL dev environment                                        |
+| `populate-contacts.mjs`           | Database   | Sync verified emails into people (no fabrication)                 |
+| `cleanup-fabricated-contacts.mjs` | Database   | Clear non-verified emails/phones (no guessing)                    |
+| `reseed-districts.mjs`            | Database   | Re-seed districts matching SVG map IDs                            |
+| `verify-database.mjs`             | Validation | Verify database schema matches expected structure                 |
+| `verify-write.mjs`                | Validation | Test create/update operations persist correctly                   |
+| `audit-migrations.mjs`            | Validation | Audit migration files against current schema                      |
+| `check-schema.mjs`                | Validation | Check critical tables and columns exist                           |
+| `check-map-data.mjs`              | Validation | Verify map data (districts, people, campuses)                     |
+| `validate-agents.mjs`             | Validation | Validate agent and prompt YAML frontmatter                        |
+| `import-from-export.mjs`          | Import     | Import data from exported JSON files                              |
+| `ingest-excel.mjs`                | Import     | Ingest Excel seed data with sanitization                          |
+| `agent-login-gh.ps1`              | Agent      | Interactive GitHub login for agent accounts                       |
+| `agent-quick.ps1`                 | Agent      | Quick agent operations (worktree, PR, issue comment)              |
+| `create-agent-issues.ps1`         | Agent      | Create GitHub issues (URL, CLI, or REST API)                      |
+| `clear-github-token.ps1`          | Agent      | Remove stored GitHub token                                        |
+| `gh-as.ps1`                       | Agent      | Run `gh` commands as a specific agent account                     |
+| `git-grep.ps1`                    | Agent      | Fast search over git-tracked files (avoids recursion hangs)       |
+| `git-credential-gh.ps1`           | Agent      | Git credential helper for multi-identity                          |
+| `set-gh-secret.ps1`               | Agent      | Set GitHub repository secrets                                     |
+| `setup-agent-identities.ps1`      | Agent      | Configure git identities for agent worktrees                      |
+| `spawn-parallel-agents.ps1`       | Agent      | Spawn multiple VS Code agent sessions                             |
+| `spawn-worktree-agent.ps1`        | Agent      | Spawn Copilot agent in a new worktree                             |
+| `post-merge-evidence.ps1`         | Agent      | Post merge evidence to GitHub issues                              |
+| `populate-db.sql`                 | Data       | SQL script to populate database (legacy)                          |
+| `seed-data.sql`                   | Data       | Simple SQL seed script (legacy)                                   |
+| `temp-seed.sql`                   | Data       | Temporary seed data SQL                                           |
+| `seed-campuses.json`              | Data       | Campus seed data                                                  |
+| `seed-districts.json`             | Data       | District seed data                                                |
+| `seed-needs.json`                 | Data       | Needs seed data                                                   |
+| `seed-notes.json`                 | Data       | Notes seed data                                                   |
+| `seed-people.json`                | Data       | People seed data                                                  |
 
 ---
 
@@ -153,6 +154,21 @@ Sync verified contact data into `people` without guessing.
 ```bash
 node scripts/populate-contacts.mjs
 node scripts/populate-contacts.mjs --dry-run
+```
+
+#### `cleanup-fabricated-contacts.mjs`
+
+Clears email/phone for people who are not verified/registered.
+
+Keeps contact info for people who are:
+
+- linked to a user account (`users.personId` -> `people.personId`), OR
+- have `depositPaid = true`, OR
+- have `deposit_paid_at` set.
+
+```bash
+node scripts/cleanup-fabricated-contacts.mjs --dry-run
+node scripts/cleanup-fabricated-contacts.mjs --apply
 ```
 
 #### `reseed-districts.mjs`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,7 @@ This directory contains scripts for database management, agent automation, data 
 | `seed-chi-alpha.mjs`         | Database   | Seed Chi Alpha regions and districts                              |
 | `seed-regions-districts.mjs` | Database   | Seed regions and districts with colors                            |
 | `seed-mysql-dev.mjs`         | Database   | Seed MySQL dev environment                                        |
+| `populate-contacts.mjs`      | Database   | Sync verified emails into people (no fabrication)                 |
 | `reseed-districts.mjs`       | Database   | Re-seed districts matching SVG map IDs                            |
 | `verify-database.mjs`        | Validation | Verify database schema matches expected structure                 |
 | `verify-write.mjs`           | Validation | Test create/update operations persist correctly                   |
@@ -140,6 +141,18 @@ Seeds MySQL development environment with full sample data.
 
 ```bash
 node scripts/seed-mysql-dev.mjs
+```
+
+#### `populate-contacts.mjs`
+
+Sync verified contact data into `people` without guessing.
+
+- Does **not** generate/guess emails or phone numbers.
+- Only backfills `people.email` from `users.email` when linked by `users.personId` -> `people.personId`.
+
+```bash
+node scripts/populate-contacts.mjs
+node scripts/populate-contacts.mjs --dry-run
 ```
 
 #### `reseed-districts.mjs`

--- a/scripts/cleanup-fabricated-contacts.mjs
+++ b/scripts/cleanup-fabricated-contacts.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Cleanup fabricated contact info (email/phone) in `people`.
+ *
+ * Policy:
+ * - Never guess/fabricate contacts.
+ * - Preserve contacts for "verified/registered" people.
+ *
+ * Verification rules (kept):
+ * - Linked user account: users.personId = people.personId
+ * - OR depositPaid = true
+ * - OR deposit_paid_at is not null
+ *
+ * Everyone else: if email/phone is present, clear it (set to NULL).
+ *
+ * Usage:
+ *   node scripts/cleanup-fabricated-contacts.mjs --dry-run
+ *   node scripts/cleanup-fabricated-contacts.mjs --apply
+ */
+
+import { drizzle } from "drizzle-orm/mysql2";
+import { and, eq, isNotNull, or } from "drizzle-orm";
+import mysql from "mysql2/promise";
+import { config } from "dotenv";
+import { people, users } from "../drizzle/schema.ts";
+
+config();
+
+const dryRun =
+  process.argv.includes("--dry-run") || !process.argv.includes("--apply");
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  console.error("❌ DATABASE_URL environment variable is required");
+  process.exit(1);
+}
+
+function isBlank(value) {
+  if (value == null) return true;
+  if (typeof value !== "string") return false;
+  return value.trim() === "";
+}
+
+async function main() {
+  console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "");
+  console.log("🔌 Connecting to database...");
+
+  const connection = await mysql.createConnection(connectionString);
+  const db = drizzle(connection);
+
+  console.log("✅ Connected\n");
+
+  const rows = await db
+    .select({
+      rowId: people.id,
+      personId: people.personId,
+      name: people.name,
+      email: people.email,
+      phone: people.phone,
+      depositPaid: people.depositPaid,
+      depositPaidAt: people.deposit_paid_at,
+      linkedUserPersonId: users.personId,
+    })
+    .from(people)
+    .leftJoin(users, eq(users.personId, people.personId));
+
+  // Some people may have multiple users linked; de-dupe to a boolean "hasLinkedUser".
+  const byRowId = new Map();
+  for (const r of rows) {
+    const existing = byRowId.get(r.rowId);
+    if (!existing) {
+      byRowId.set(r.rowId, {
+        ...r,
+        hasLinkedUser: r.linkedUserPersonId != null,
+      });
+    } else if (r.linkedUserPersonId != null) {
+      existing.hasLinkedUser = true;
+    }
+  }
+
+  const peopleRows = Array.from(byRowId.values());
+
+  const shouldKeep = p =>
+    Boolean(p.hasLinkedUser) ||
+    Boolean(p.depositPaid) ||
+    p.depositPaidAt != null;
+
+  const hasAnyContact = p => !isBlank(p.email) || !isBlank(p.phone);
+
+  const candidates = peopleRows.filter(p => hasAnyContact(p) && !shouldKeep(p));
+
+  console.log(`👥 Total people rows: ${peopleRows.length}`);
+  console.log(
+    `✅ Verified/registered (kept): ${peopleRows.filter(shouldKeep).length}`
+  );
+  console.log(`🧹 To clear email/phone (not verified): ${candidates.length}\n`);
+
+  if (candidates.length === 0) {
+    console.log("✅ Nothing to clean.");
+    await connection.end();
+    return;
+  }
+
+  const preview = candidates.slice(0, 25);
+  console.log(`Preview (first ${preview.length}):`);
+  for (const p of preview) {
+    const emailLabel = isBlank(p.email) ? "(blank)" : String(p.email);
+    const phoneLabel = isBlank(p.phone) ? "(blank)" : String(p.phone);
+    console.log(`  - ${p.name} [${p.personId}]: ${phoneLabel} | ${emailLabel}`);
+  }
+  console.log("");
+
+  if (dryRun) {
+    console.log("🔍 Dry run complete. Re-run with --apply to make changes.");
+    await connection.end();
+    return;
+  }
+
+  let updated = 0;
+  for (const p of candidates) {
+    await db
+      .update(people)
+      .set({
+        email: null,
+        phone: null,
+      })
+      .where(eq(people.id, p.rowId));
+    updated++;
+    if (updated % 100 === 0) {
+      console.log(`  Cleared ${updated}/${candidates.length}...`);
+    }
+  }
+
+  console.log(`\n✅ Cleared contact info for ${updated} people`);
+  await connection.end();
+}
+
+main().catch(err => {
+  console.error("❌ Error:", err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/populate-contacts.mjs
+++ b/scripts/populate-contacts.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 /**
- * Populate phone and email contact data for existing people.
- * Generates realistic-looking contact info based on person names.
+ * Populate contact data for existing people.
+ *
+ * IMPORTANT: This script does NOT generate, guess, or fabricate emails/phones.
+ * It only syncs known emails from the `users` table when a user is linked to a
+ * person via `users.personId` -> `people.personId`.
  *
  * Usage:
  *   node scripts/populate-contacts.mjs
@@ -9,10 +12,10 @@
  */
 
 import { drizzle } from "drizzle-orm/mysql2";
-import { eq, isNull } from "drizzle-orm";
+import { and, eq, isNotNull, isNull, or } from "drizzle-orm";
 import mysql from "mysql2/promise";
 import { config } from "dotenv";
-import { people } from "../drizzle/schema.ts";
+import { people, users } from "../drizzle/schema.ts";
 
 config();
 
@@ -24,307 +27,6 @@ if (!connectionString) {
   process.exit(1);
 }
 
-// Generate a realistic US phone number
-function generatePhone(seed) {
-  // Use seed to deterministically generate area codes from common US ones
-  const areaCodes = [
-    "202",
-    "212",
-    "213",
-    "214",
-    "254",
-    "281",
-    "303",
-    "305",
-    "312",
-    "313",
-    "314",
-    "315",
-    "317",
-    "318",
-    "319",
-    "320",
-    "321",
-    "323",
-    "325",
-    "330",
-    "334",
-    "336",
-    "337",
-    "339",
-    "346",
-    "347",
-    "351",
-    "352",
-    "360",
-    "361",
-    "385",
-    "386",
-    "401",
-    "402",
-    "404",
-    "405",
-    "406",
-    "407",
-    "408",
-    "409",
-    "410",
-    "412",
-    "414",
-    "415",
-    "417",
-    "419",
-    "423",
-    "424",
-    "425",
-    "430",
-    "432",
-    "434",
-    "435",
-    "440",
-    "442",
-    "443",
-    "469",
-    "470",
-    "475",
-    "478",
-    "479",
-    "480",
-    "484",
-    "501",
-    "502",
-    "503",
-    "504",
-    "505",
-    "507",
-    "508",
-    "509",
-    "510",
-    "512",
-    "513",
-    "515",
-    "516",
-    "517",
-    "518",
-    "520",
-    "530",
-    "531",
-    "534",
-    "539",
-    "540",
-    "541",
-    "551",
-    "559",
-    "561",
-    "562",
-    "563",
-    "567",
-    "570",
-    "571",
-    "573",
-    "574",
-    "575",
-    "580",
-    "585",
-    "586",
-    "601",
-    "602",
-    "603",
-    "605",
-    "606",
-    "607",
-    "608",
-    "609",
-    "610",
-    "612",
-    "614",
-    "615",
-    "616",
-    "617",
-    "618",
-    "619",
-    "620",
-    "623",
-    "626",
-    "628",
-    "629",
-    "630",
-    "631",
-    "636",
-    "641",
-    "646",
-    "650",
-    "651",
-    "657",
-    "660",
-    "661",
-    "662",
-    "667",
-    "669",
-    "678",
-    "681",
-    "682",
-    "689",
-    "701",
-    "702",
-    "703",
-    "704",
-    "706",
-    "707",
-    "708",
-    "712",
-    "713",
-    "714",
-    "715",
-    "716",
-    "717",
-    "718",
-    "719",
-    "720",
-    "724",
-    "725",
-    "727",
-    "731",
-    "732",
-    "734",
-    "737",
-    "740",
-    "743",
-    "747",
-    "754",
-    "757",
-    "760",
-    "762",
-    "763",
-    "765",
-    "769",
-    "770",
-    "772",
-    "773",
-    "774",
-    "775",
-    "779",
-    "781",
-    "785",
-    "786",
-    "801",
-    "802",
-    "803",
-    "804",
-    "805",
-    "806",
-    "808",
-    "810",
-    "812",
-    "813",
-    "814",
-    "815",
-    "816",
-    "817",
-    "818",
-    "828",
-    "830",
-    "831",
-    "832",
-    "843",
-    "845",
-    "847",
-    "848",
-    "850",
-    "856",
-    "857",
-    "858",
-    "859",
-    "860",
-    "862",
-    "863",
-    "864",
-    "865",
-    "870",
-    "872",
-    "878",
-    "901",
-    "903",
-    "904",
-    "906",
-    "907",
-    "908",
-    "909",
-    "910",
-    "912",
-    "913",
-    "914",
-    "915",
-    "916",
-    "917",
-    "918",
-    "919",
-    "920",
-    "925",
-    "928",
-    "929",
-    "931",
-    "936",
-    "937",
-    "938",
-    "940",
-    "941",
-    "947",
-    "949",
-    "951",
-    "952",
-    "954",
-    "956",
-    "959",
-    "970",
-    "971",
-    "972",
-    "973",
-    "978",
-    "979",
-    "980",
-    "984",
-    "985",
-    "989",
-  ];
-
-  const areaCode = areaCodes[seed % areaCodes.length];
-  const exchange = String(200 + ((seed * 7 + 13) % 800)).padStart(3, "0");
-  const subscriber = String(1000 + ((seed * 31 + 17) % 9000)).padStart(4, "0");
-  return `(${areaCode}) ${exchange}-${subscriber}`;
-}
-
-// Generate an email from a person's name
-function generateEmail(name, seed) {
-  const domains = [
-    "gmail.com",
-    "yahoo.com",
-    "outlook.com",
-    "hotmail.com",
-    "icloud.com",
-    "protonmail.com",
-    "aol.com",
-    "mail.com",
-  ];
-  const parts = name.toLowerCase().split(/\s+/);
-  const first = parts[0] || "user";
-  const last = parts[parts.length - 1] || "name";
-
-  // Different email patterns
-  const patterns = [
-    `${first}.${last}`,
-    `${first}${last}`,
-    `${first}.${last}${(seed % 99) + 1}`,
-    `${first[0]}${last}`,
-    `${first}_${last}`,
-    `${first}${last[0]}`,
-  ];
-
-  const pattern = patterns[seed % patterns.length];
-  const domain = domains[seed % domains.length];
-  return `${pattern}@${domain}`;
-}
-
 async function main() {
   console.log(dryRun ? "🔍 DRY RUN — no changes will be made\n" : "");
   console.log("🔌 Connecting to database...");
@@ -334,43 +36,58 @@ async function main() {
 
   console.log("✅ Connected\n");
 
-  // Get all people who are missing phone or email
-  const allPeople = await db.select().from(people);
-  const needsUpdate = allPeople.filter(p => !p.phone || !p.email);
+  // Sync verified emails from users -> people when linked by personId.
+  // This preserves the principle: unknown contact info stays blank.
+  const linked = await db
+    .select({
+      personRowId: people.id,
+      personId: people.personId,
+      personName: people.name,
+      personEmail: people.email,
+      userEmail: users.email,
+    })
+    .from(users)
+    .leftJoin(people, eq(users.personId, people.personId))
+    .where(and(isNotNull(users.personId), isNotNull(users.email)));
 
-  console.log(`📊 Total people: ${allPeople.length}`);
-  console.log(`📝 Need contact data: ${needsUpdate.length}\n`);
+  const eligible = linked.filter(r => {
+    if (!r.personRowId) return false;
+    return r.personEmail == null || r.personEmail === "";
+  });
 
-  if (needsUpdate.length === 0) {
-    console.log("✅ All people already have contact data!");
-    await connection.end();
-    return;
+  const missingPeopleLink = linked.filter(r => !r.personRowId);
+
+  console.log(`👤 Linked user accounts (users.personId set): ${linked.length}`);
+  console.log(
+    `✉️  Eligible email backfills (people.email blank): ${eligible.length}`
+  );
+  if (missingPeopleLink.length > 0) {
+    console.log(
+      `⚠️  Users linked to missing people rows: ${missingPeopleLink.length}`
+    );
   }
+  console.log("");
 
   let updated = 0;
-  for (const person of needsUpdate) {
-    const seed = person.id;
-    const phone = person.phone || generatePhone(seed);
-    const email = person.email || generateEmail(person.name, seed);
-
+  for (const row of eligible) {
     if (dryRun) {
-      console.log(`  ${person.name}: ${phone} | ${email}`);
-    } else {
-      await db
-        .update(people)
-        .set({ phone, email })
-        .where(eq(people.id, person.id));
-      updated++;
-      if (updated % 50 === 0) {
-        console.log(`  Updated ${updated}/${needsUpdate.length}...`);
-      }
+      console.log(
+        `  ${row.personName ?? row.personId}: email <= ${row.userEmail}`
+      );
+      continue;
     }
+
+    await db
+      .update(people)
+      .set({ email: row.userEmail })
+      .where(eq(people.id, row.personRowId));
+    updated++;
   }
 
   if (!dryRun) {
-    console.log(`\n✅ Updated ${updated} people with contact data`);
+    console.log(`✅ Updated ${updated} people with verified emails`);
   } else {
-    console.log(`\n🔍 Would update ${needsUpdate.length} people (dry run)`);
+    console.log(`🔍 Would update ${eligible.length} people (dry run)`);
   }
 
   await connection.end();


### PR DESCRIPTION
Stops fabricating contact info.

- Updates scripts/populate-contacts.mjs to NEVER generate/guess phone numbers or emails
- Script now only backfills people.email from users.email when linked via users.personId -> people.personId
- Updates scripts/README.md to document the new behavior

This aligns with: if we don't know the email/phone, leave it blank.