### PR TITLE
Change donation campaign deadline to July 1, 2026

### DIFF
--- a/shared/const.ts
+++ b/shared/const.ts
@@ -5,8 +5,8 @@ export const UNAUTHED_ERR_MSG = "Please login (10001)";
 export const NOT_ADMIN_ERR_MSG = "You do not have required permission (10002)";
 
 export const DONATION_CAMPAIGN_GOAL_CENTS = 8_200_00;
-export const DONATION_CAMPAIGN_DEADLINE_ISO = "2026-06-06";
-export const DONATION_CAMPAIGN_DEADLINE_LABEL = "June 6, 2026";
+export const DONATION_CAMPAIGN_DEADLINE_ISO = "2026-07-01";
+export const DONATION_CAMPAIGN_DEADLINE_LABEL = "July 1, 2026";
 
 /**
  * Donors who contributed before the live Stripe campaign opened.


### PR DESCRIPTION
## Summary
Updates the donation campaign deadline (shown as "Deadline: June 6, 2026" on the `/donate` page) to **July 1, 2026**.

## Changes
- `shared/const.ts`: `DONATION_CAMPAIGN_DEADLINE_ISO` → `2026-07-01`
- `shared/const.ts`: `DONATION_CAMPAIGN_DEADLINE_LABEL` → `July 1, 2026`

These constants flow through the server router and the Donate page UI, so both the displayed label and the underlying date update together. The donations test references the constants directly, so it remains consistent.

https://claude.ai/code/session_01VPyt96JFe5jVrXcVz3x91z

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPyt96JFe5jVrXcVz3x91z)_